### PR TITLE
Add workflow to preview README renderings on PRs

### DIFF
--- a/.github/workflows/render-readme.yml
+++ b/.github/workflows/render-readme.yml
@@ -1,0 +1,40 @@
+name: Render README preview
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  generate-preview:
+    name: Generate README preview
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Render README to PNG
+        run: go run . -in README.md -out output.png
+
+      - name: Encode image
+        id: encode
+        run: echo "data=$(base64 -w0 output.png)" >> "$GITHUB_OUTPUT"
+
+      - name: Post preview comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-identifier: md2png-preview
+          body: |
+            ## README Preview
+            ![Rendered README](data:image/png;base64,${{ steps.encode.outputs.data }})


### PR DESCRIPTION
## Summary
- add a pull request workflow that renders README.md to output.png
- post the generated image as a persistent comment on the pull request

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eee5827c68832fa82f8d9feaa2b31e