### PR TITLE
Fix README preview workflow permissions

### DIFF
--- a/.github/workflows/render-readme.yml
+++ b/.github/workflows/render-readme.yml
@@ -12,6 +12,10 @@ jobs:
   generate-preview:
     name: Generate README preview
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- grant the README preview workflow the permissions it needs to post comments on pull requests

## Testing
- go run . -in README.md -out output.png

------
https://chatgpt.com/codex/tasks/task_e_68eeee1079a8832fa16776cc735f10db