### PR TITLE
Move CLI entrypoint into cmd and expose library API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# md2img – Markdown to Image (Go CLI)
+# md2png – Markdown to Image (Go CLI & Library)
 
-`md2img` is a **pure Go command-line tool** that converts Markdown files directly into **PNG** or **JPG** images — no JavaScript, no Python, no scripting runtimes required.
+`md2png` is a **pure Go toolkit** that converts Markdown files directly into **PNG** or **JPG** images — no JavaScript, no Python, no scripting runtimes required. Use the bundled CLI or import it as a library in your own Go projects.
 
 It’s designed for developers who want a **self-contained binary** that can render Markdown into readable, styled images for documentation, blog headers, code snippets, or social previews.
 
@@ -30,9 +30,9 @@ It’s designed for developers who want a **self-contained binary** that can ren
 ### Clone & Build
 
 ```bash
-git clone https://github.com/arran4/md2img.git
-cd md2img
-go build -o md2img
+git clone https://github.com/arran4/md2png.git
+cd md2png
+go build ./cmd/md2png
 ```
 
 ### Dependencies
@@ -52,7 +52,7 @@ No external tools required — just Go ≥1.22.
 ## 🚀 Usage
 
 ```bash
-./md2img -in README.md -out out.png
+./md2png -in README.md -out out.png
 ```
 
 ### Options
@@ -76,19 +76,19 @@ No external tools required — just Go ≥1.22.
 Render a Markdown file to PNG:
 
 ```bash
-./md2img -in example.md -out example.png
+./md2png -in example.md -out example.png
 ```
 
 Dark theme with larger font and wider layout:
 
 ```bash
-./md2img -in blogpost.md -out post.png -theme dark -width 1400 -pt 18
+./md2png -in blogpost.md -out post.png -theme dark -width 1400 -pt 18
 ```
 
 Using your own fonts:
 
 ```bash
-./md2img -in notes.md -out notes.jpg \
+./md2png -in notes.md -out notes.jpg \
   -font /usr/share/fonts/TTF/DejaVuSans.ttf \
   -fontmono /usr/share/fonts/TTF/DejaVuSansMono.ttf
 ```
@@ -96,8 +96,44 @@ Using your own fonts:
 Pipe Markdown directly:
 
 ```bash
-echo "# Hello\nThis came from stdin!" | ./md2img -out hello.png
+echo "# Hello\nThis came from stdin!" | ./md2png -out hello.png
 ```
+
+---
+
+## 📦 Library Usage
+
+Import `github.com/arran4/md2png` to render Markdown from your own Go code:
+
+```go
+package main
+
+import (
+        "image/png"
+        "os"
+
+        "github.com/arran4/md2png"
+)
+
+func main() {
+        img, err := md2png.Render([]byte("# Hello\nRendered inside Go!"), md2png.RenderOptions{})
+        if err != nil {
+                panic(err)
+        }
+
+        f, err := os.Create("hello.png")
+        if err != nil {
+                panic(err)
+        }
+        defer f.Close()
+
+        if err := png.Encode(f, img); err != nil {
+                panic(err)
+        }
+}
+```
+
+`RenderOptions` accepts custom dimensions, themes, and fonts. To load your own TTFs, call `md2png.LoadFonts` and pass the result to `RenderOptions.Fonts`.
 
 ---
 

--- a/cmd/md2png/main.go
+++ b/cmd/md2png/main.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"image/jpeg"
+	"image/png"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/arran4/md2png"
+)
+
+func main() {
+	in := flag.String("in", "", "Input Markdown file (default: stdin if empty)")
+	out := flag.String("out", "out.png", "Output image file (.png or .jpg)")
+	width := flag.Int("width", 1024, "Output image width in pixels")
+	margin := flag.Int("margin", 48, "Margin in pixels")
+	pt := flag.Float64("pt", 16, "Base font size in points (paragraph)")
+	theme := flag.String("theme", "light", "Theme: light|dark")
+	fontRegular := flag.String("font", "", "Path to TTF for regular text (optional; default Go Regular)")
+	fontBold := flag.String("fontbold", "", "Path to TTF for bold text (optional; default Go Bold)")
+	fontMono := flag.String("fontmono", "", "Path to TTF for mono/code (optional; default Go Mono)")
+	flag.Parse()
+
+	th, err := md2png.ThemeByName(*theme)
+	if err != nil {
+		fatal(err)
+	}
+
+	fonts, err := md2png.LoadFonts(md2png.FontConfig{
+		RegularPath: *fontRegular,
+		BoldPath:    *fontBold,
+		MonoPath:    *fontMono,
+		SizeBase:    *pt,
+	})
+	if err != nil {
+		fatal(err)
+	}
+
+	var data []byte
+	if *in == "" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		var f *os.File
+		f, err = os.Open(*in)
+		if err != nil {
+			fatal(err)
+		}
+		defer f.Close()
+		data, err = io.ReadAll(f)
+	}
+	if err != nil {
+		fatal(err)
+	}
+
+	img, err := md2png.Render(data, md2png.RenderOptions{
+		Width:        *width,
+		Margin:       *margin,
+		BaseFontSize: *pt,
+		Theme:        th,
+		Fonts:        fonts,
+	})
+	if err != nil {
+		fatal(err)
+	}
+
+	file, err := os.Create(*out)
+	if err != nil {
+		fatal(err)
+	}
+	defer file.Close()
+
+	ext := strings.ToLower(filepath.Ext(*out))
+	switch ext {
+	case ".png":
+		if err := png.Encode(file, img); err != nil {
+			fatal(err)
+		}
+	case ".jpg", ".jpeg":
+		if err := jpeg.Encode(file, img, &jpeg.Options{Quality: 92}); err != nil {
+			fatal(err)
+		}
+	default:
+		fatal(errors.New("unsupported output extension: " + ext))
+	}
+}
+
+func fatal(err error) {
+	_, _ = os.Stderr.WriteString("md2png: " + err.Error() + "\n")
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary
- expose the renderer as an importable package with exported options and helpers
- add a cmd/md2png entrypoint that wraps the package API for CLI usage
- document the CLI location and new library usage example in the README

## Testing
- go test ./...
- ./md2png -in README.md -out output.png

------
https://chatgpt.com/codex/tasks/task_e_68eeee3631f8832f891149501ebfc7c4