### PR TITLE
Fix README render workflow command path

### DIFF
--- a/.github/workflows/render-readme.yml
+++ b/.github/workflows/render-readme.yml
@@ -27,7 +27,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Render README to PNG
-        run: go run . -in README.md -out output.png
+        run: go run ./cmd/md2png -in README.md -out output.png
 
       - name: Post preview comment
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- update the render README workflow to run the CLI from its new location

## Testing
- go run ./cmd/md2png -in README.md -out output.png


------
https://chatgpt.com/codex/tasks/task_e_68eef0cba1c0832f84af2977c5b89634