### PR TITLE
Render README image in releases

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,9 @@ before:
     - go mod tidy
     # Run the full test suite so releases only ship green builds.
     - go test ./...
+    # Render the README to a PNG so releases can ship the up-to-date output.
+    - mkdir -p dist
+    - go run . -in README.md -out dist/README.png
 
 builds:
   - id: md2png
@@ -58,6 +61,8 @@ archives:
     files:
       - README.md
       - example.png
+      - src: dist/README.png
+        dst: README.png
     replacements:
       darwin: macOS
       linux: Linux
@@ -154,6 +159,8 @@ release:
   github:
     owner: arran4
     name: md2png
+  extra_files:
+    - glob: dist/README.png
   draft: false
   prerelease: auto
   footer: |


### PR DESCRIPTION
## Summary
- render the README to a PNG as part of the release hooks
- include the generated README image in both the archives and as a standalone release asset

## Testing
- go test ./...
- go run ./cmd/md2png -in README.md -out dist/README.png


------
https://chatgpt.com/codex/tasks/task_e_68ef0a939df8832f8beba4a858bd554b