### PR TITLE
Improve Markdown layout spacing and support

### DIFF
--- a/testdata/rendering.md
+++ b/testdata/rendering.md
@@ -1,0 +1,34 @@
+# Rendering Feature Showcase
+
+Paragraph one with a [link example](https://example.com) to check underline styling.
+
+Second paragraph follows to ensure the 1.5 line paragraph spacing is visible.
+
+1. First numbered item
+   1. Nested number one
+      - Nested bullet keeps indentation
+   2. Nested number two
+2. Second numbered item with more text to verify sequential numbering and spacing.
+
+- Bullet alpha
+- Bullet beta
+  - Sub bullet beta-one
+    - Sub bullet beta-two continues depth
+- Bullet gamma after nested items
+
+```
+    code block should keep leading spaces
+    and    multiple    internal    spaces
+```
+
+> Blockquote with a [link](https://openai.com) nested inside.
+
+| Name | Description |
+| ---- | ----------- |
+| Foo  | A sample entry |
+| Bar  | Another entry |
+
+This HTML should be flagged:
+
+<div>Unsupported HTML block</div>
+


### PR DESCRIPTION
## Summary
- enhance theming, link styling, and spacing logic to satisfy paragraph, list, and numbering requirements including nested list support
- preserve code block whitespace, render tables, and flag unsupported block types while improving text wrapping and list handling
- add a rendering feature markdown fixture covering links, lists, tables, code blocks, and unsupported syntax

## Testing
- go test ./...
- (cd cmd/md2png && go run . -in ../../README.md -out ../../output.png)


------
https://chatgpt.com/codex/tasks/task_e_68ef0a5a3c38832f9152a19cf4a171ce