### PR TITLE
Fix inline formatting inside list items

### DIFF
--- a/md2png_test.go
+++ b/md2png_test.go
@@ -1,0 +1,89 @@
+package md2png
+
+import (
+	"image"
+	"strings"
+	"testing"
+)
+
+func TestWrapLinesPreservesIndentation(t *testing.T) {
+	fonts, err := LoadFonts(FontConfig{SizeBase: 14})
+	if err != nil {
+		t.Fatalf("load fonts: %v", err)
+	}
+	text := "    spaced  out"
+	lines := wrapLines(fonts.Mono, 14, text, 140)
+	if len(lines) == 0 {
+		t.Fatalf("expected at least one line")
+	}
+	if !strings.HasPrefix(lines[0], "    ") {
+		t.Fatalf("expected leading spaces to be preserved, got %q", lines[0])
+	}
+	joined := strings.Join(lines, "")
+	if !strings.Contains(joined, "  out") {
+		t.Fatalf("expected double spaces inside wrapped lines to be preserved, got %q", joined)
+	}
+
+	long := "averyverylongtokenwithoutspaces"
+	longLines := wrapLines(fonts.Mono, 14, long, 80)
+	if len(longLines) < 2 {
+		t.Fatalf("expected long token to wrap across multiple lines, got %v", longLines)
+	}
+}
+
+func TestRenderHandlesTablesAndUnsupported(t *testing.T) {
+	markdown := `# Title
+
+Paragraph text before list.
+
+- Item one
+  - Nested bullet
+
+1. First ordered item
+2. Second ordered item
+   1. Nested ordered item
+
+| A | B |
+| --- | --- |
+| 1 | 2 |
+| 3 | 4 |
+
+::: custom
+Unsupported block
+:::
+`
+
+	img, err := Render([]byte(markdown), RenderOptions{})
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+	if img == nil {
+		t.Fatalf("expected image result")
+	}
+	if img.Bounds() == (image.Rectangle{}) {
+		t.Fatalf("expected non-empty bounds")
+	}
+}
+
+func TestRenderListInlineFormatting(t *testing.T) {
+	markdown := "- **bold text** with `iiWW` and a [link](https://example.com)\n"
+	img, err := Render([]byte(markdown), RenderOptions{Width: 640, Margin: 48, BaseFontSize: 18})
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	bounds := img.Bounds()
+	foundLinkPixel := false
+	for y := bounds.Min.Y; y < bounds.Max.Y && !foundLinkPixel; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r, g, b, a := img.At(x, y).RGBA()
+			if uint8(r>>8) == linkColor.R && uint8(g>>8) == linkColor.G && uint8(b>>8) == linkColor.B && uint8(a>>8) == linkColor.A {
+				foundLinkPixel = true
+				break
+			}
+		}
+	}
+	if !foundLinkPixel {
+		t.Fatalf("expected rendered list item to include link styling pixel")
+	}
+}

--- a/testdata/all_features.md
+++ b/testdata/all_features.md
@@ -1,0 +1,44 @@
+# Rendering Showcase
+
+Paragraph one demonstrates the new paragraph spacing. It should feel like there is extra breathing room before the next paragraph.
+
+Paragraph two follows immediately after the first to highlight the 1.5 line break spacing requirement.
+
+## Lists
+
+- Top level bullet
+  - Nested bullet one
+    - Nested bullet two
+- Second bullet with more text to ensure wrapping behaviour is visible when the content flows onto another line within the same list item.
+
+1. First ordered item
+2. Second ordered item
+   1. Nested ordered item
+   2. Another nested ordered item with enough text to wrap around onto the next line and show numbering alignment.
+3. Third ordered item after the nested list.
+
+## Code
+
+```
+    def example(value):
+        print("value:", value)
+        return value * 2
+```
+
+## Links
+
+Here is a [link that should look blue and underlined](https://example.com) inside the text.
+
+## Table
+
+| Feature | Status |
+| :------ | :----- |
+| Tables  | Rendered |
+| Links   | Blue and underlined |
+| Lists   | Support nesting |
+
+## Unsupported Syntax
+
+::: custom-block
+This block should display a warning indicator because the renderer does not support the `:::` syntax yet.
+:::


### PR DESCRIPTION
## Summary
- preserve whitespace and add link styling while drawing inline tokens, including blue underlined links
- rework list rendering to support nested ordered/bullet items with improved spacing and add basic table drawing with unsupported syntax warnings
- keep code block indentation, adjust paragraph spacing, and add a feature showcase fixture plus renderer tests
- ensure inline formatting inside list text blocks uses the full inline renderer so bold text, inline code, and links render correctly, and add regression coverage that checks for link styling in list output

## Testing
- go test ./...
- go run ./cmd/md2png -in README.md -out output.png

------
https://chatgpt.com/codex/tasks/task_e_68ef0a5a3c38832f9152a19cf4a171ce