### PR TITLE
Add download links to README output examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ func main() {
 
 ## 🧩 Output Example
 
-**Light Theme**
+**Light Theme** · [Download PNG](examples/light-example.png)
 
 ![Light example](examples/light-example.png)
 
-**Dark Theme**
+**Dark Theme** · [Download PNG](examples/dark-example.png)
 
 ![Dark example](examples/dark-example.png)
 


### PR DESCRIPTION
## Summary
- add direct download links to the light and dark example images in the README

## Testing
- go run ./cmd/md2png -in README.md -out output.png

------
https://chatgpt.com/codex/tasks/task_e_68ef13cf49a8832f87a44e2ea94219a5