### PR TITLE
Add configurable footnote rendering for links and images

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ No external tools required — just Go ≥1.22.
 | `-font` | Regular font (TTF path) | built-in Go Regular |
 | `-fontbold` | Bold font (TTF path) | built-in Go Bold |
 | `-fontmono` | Monospace font (TTF path) | built-in Go Mono |
+| `-footnote-links` | Append link destinations as numbered footnotes | `true` |
+| `-footnote-images` | Append image destinations as numbered footnotes | `false` |
 
 ---
 
@@ -133,7 +135,7 @@ func main() {
 }
 ```
 
-`RenderOptions` accepts custom dimensions, themes, and fonts. To load your own TTFs, call `md2png.LoadFonts` and pass the result to `RenderOptions.Fonts`.
+`RenderOptions` accepts custom dimensions, themes, fonts, and footnote toggles. To load your own TTFs, call `md2png.LoadFonts` and pass the result to `RenderOptions.Fonts`. Set `RenderOptions.LinkFootnotes` or `RenderOptions.ImageFootnotes` to override the default link/image footnote behavior from code.
 
 ---
 

--- a/cmd/md2png/main.go
+++ b/cmd/md2png/main.go
@@ -23,6 +23,8 @@ func main() {
 	fontRegular := flag.String("font", "", "Path to TTF for regular text (optional; default Go Regular)")
 	fontBold := flag.String("fontbold", "", "Path to TTF for bold text (optional; default Go Bold)")
 	fontMono := flag.String("fontmono", "", "Path to TTF for mono/code (optional; default Go Mono)")
+	footnoteLinks := flag.Bool("footnote-links", true, "Add footnotes for link destinations")
+	footnoteImages := flag.Bool("footnote-images", false, "Add footnotes for image destinations")
 	flag.Parse()
 
 	th, err := md2png.ThemeByName(*theme)
@@ -57,11 +59,13 @@ func main() {
 	}
 
 	img, err := md2png.Render(data, md2png.RenderOptions{
-		Width:        *width,
-		Margin:       *margin,
-		BaseFontSize: *pt,
-		Theme:        th,
-		Fonts:        fonts,
+		Width:          *width,
+		Margin:         *margin,
+		BaseFontSize:   *pt,
+		Theme:          th,
+		Fonts:          fonts,
+		LinkFootnotes:  footnoteLinks,
+		ImageFootnotes: footnoteImages,
 	})
 	if err != nil {
 		fatal(err)


### PR DESCRIPTION
## Summary
- add link and image URL footnote collection with deduplicated numbering during rendering
- expose CLI flags and RenderOptions toggles to control link and image footnotes and document their defaults
- cover the new behavior with renderer and integration tests

## Testing
- go test ./...
- (cd cmd/md2png && go run . -in ../../README.md -out ../../output.png)


------
https://chatgpt.com/codex/tasks/task_e_68ef149fc598832f95c69eaa32110b44