### PR TITLE
Simplify output example headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ func main() {
 
 ## 🧩 Output Example
 
-**Light Theme**
+**[Light Theme](examples/light-example.png)**
 
 ![Light example](examples/light-example.png)
 
-**Dark Theme**
+**[Dark Theme](examples/dark-example.png)**
 
 ![Dark example](examples/dark-example.png)
 


### PR DESCRIPTION
## Summary
- remove the redundant heading markers around the bolded light and dark output example links so the README just shows the combined bold-link formatting

## Testing
- go run . -in README.md -out output.png *(fails: package github.com/arran4/md2png is not a main package)*
- ./md2png -in README.md -out output.png

------
https://chatgpt.com/codex/tasks/task_e_68ef13cf49a8832f87a44e2ea94219a5