### PR TITLE
Add inline image rendering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It’s designed for developers who want a **self-contained binary** that can ren
     - Code blocks (monospaced background)
     - Blockquotes (with left accent bar)
     - Horizontal rules (`---`, `***`)
+    - Inline images (`![](path/to/image.png)`)
 - **Light & Dark themes**
 - **Custom fonts** (`--font`, `--fontbold`, and `--fontmono`)
 - **Adjustable width, margins, and font size**
@@ -163,7 +164,7 @@ All rendering happens in memory — no HTML or external conversion.
 ## 🧠 Roadmap
 
 - [ ] Tables
-- [ ] Inline images
+- [x] Inline images
 - [ ] Syntax highlighting
 - [ ] SVG output
 - [ ] Configurable themes via YAML/JSON

--- a/cmd/md2png/main.go
+++ b/cmd/md2png/main.go
@@ -56,12 +56,22 @@ func main() {
 		fatal(err)
 	}
 
+	var resolver md2png.ImageResolver
+	if *in != "" {
+		resolver = md2png.FileSystemImageResolver(filepath.Dir(*in))
+	} else {
+		if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+			resolver = md2png.FileSystemImageResolver(cwd)
+		}
+	}
+
 	img, err := md2png.Render(data, md2png.RenderOptions{
-		Width:        *width,
-		Margin:       *margin,
-		BaseFontSize: *pt,
-		Theme:        th,
-		Fonts:        fonts,
+		Width:         *width,
+		Margin:        *margin,
+		BaseFontSize:  *pt,
+		Theme:         th,
+		Fonts:         fonts,
+		ImageResolver: resolver,
 	})
 	if err != nil {
 		fatal(err)


### PR DESCRIPTION
## Summary
- add inline image rendering support with scaling and fallbacks
- add a filesystem-backed image resolver and wire it through the CLI
- document image support and cover it with a unit test

## Testing
- go test ./...
- go run ./cmd/md2png -in README.md -out output.png

------
https://chatgpt.com/codex/tasks/task_e_68ef13db3098832f8942f502f7fbeb25