### PR TITLE
Support remote image resolvers

### DIFF
--- a/cmd/md2png/main.go
+++ b/cmd/md2png/main.go
@@ -43,8 +43,12 @@ func main() {
 	}
 
 	var data []byte
+	var baseDir string
 	if *in == "" {
 		data, err = io.ReadAll(os.Stdin)
+		if err == nil {
+			baseDir, err = os.Getwd()
+		}
 	} else {
 		var f *os.File
 		f, err = os.Open(*in)
@@ -53,6 +57,9 @@ func main() {
 		}
 		defer f.Close()
 		data, err = io.ReadAll(f)
+		if err == nil {
+			baseDir, err = filepath.Abs(filepath.Dir(*in))
+		}
 	}
 	if err != nil {
 		fatal(err)
@@ -66,6 +73,7 @@ func main() {
 		Fonts:          fonts,
 		LinkFootnotes:  footnoteLinks,
 		ImageFootnotes: footnoteImages,
+		BaseDir:        baseDir,
 	})
 	if err != nil {
 		fatal(err)


### PR DESCRIPTION
## Summary
- render inline markdown images by loading local assets, caching them, and scaling to fit the canvas
- add base directory resolution to the renderer and CLI so relative image paths work
- add pluggable URI-based image resolvers so HTTP/HTTPS images load alongside local files
- cover local and remote image embedding with regression tests

## Testing
- go test ./...
- go run ./cmd/md2png -in README.md -out output.png

------
https://chatgpt.com/codex/tasks/task_e_68ef1de1971c832fa286f1bc8d693493