### PR TITLE
Fix invalid expression in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   goreleaser:
-    if: ${{ github.ref_type == 'tag' && startsWith(github.ref_name, 'v') && github.ref_name matches '^v[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?(\\+[0-9A-Za-z.-]+)?$' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- simplify the release workflow condition to use startsWith on the tag ref, avoiding the unsupported matches operator

## Testing
- go run . -in README.md -out output.png *(fails: package github.com/arran4/md2png is not a main package)*

------
https://chatgpt.com/codex/tasks/task_e_68ef447a2f74832f819fbcb1d3d24c17