### PR TITLE
Update goreleaser config for v1.26

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,13 +63,7 @@ archives:
       - readme.png
       - src: dist/README.png
         dst: README.png
-    replacements:
-      darwin: macOS
-      linux: Linux
-      windows: Windows
-      386: i386
-      amd64: x86_64
-    name_template: '{{ .ProjectName }}_{{ .Version }}_{{- title .Os }}_{{- .Arch }}{{- with .Arm }}v{{ . }}{{ end }}'
+    name_template: '{{ .ProjectName }}_{{ .Version }}_{{- if eq .Os "darwin" }}macOS{{ else if eq .Os "linux" }}Linux{{ else if eq .Os "windows" }}Windows{{ else }}{{ title .Os }}{{ end }}_{{- if eq .Arch "386" }}i386{{ else if eq .Arch "amd64" }}x86_64{{ else }}{{ .Arch }}{{ end }}{{- with .Arm }}v{{ . }}{{ end }}'
 
 checksum:
   name_template: '{{ .ProjectName }}_checksums.txt'
@@ -142,9 +136,6 @@ scoops:
     description: 'Render Markdown to PNG/JPG with a single static Go binary.'
     homepage: 'https://github.com/arran4/md2png'
     license: MIT
-    checkver: github
-    autoupdate:
-      url: 'https://github.com/arran4/md2png/releases/download/{{ .Tag }}/{{ .ArtifactName }}'
 
 changelog:
   use: github


### PR DESCRIPTION
## Summary
- update archive naming to use template conditionals supported by GoReleaser v1.26
- remove Scoop fields that are no longer supported in GoReleaser v1.26

## Testing
- go test ./...
- go run ./cmd/md2png -in README.md -out output.png

------
https://chatgpt.com/codex/tasks/task_e_68ef47b3d43c832fa1e49daf2d9b6352