### PR TITLE
Add GIF output mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ No external tools required — just Go ≥1.22.
 | Flag | Description | Default |
 |------|--------------|----------|
 | `-in` | Input Markdown file (use stdin if empty) | — |
-| `-out` | Output image file (.png or .jpg) | `out.png` |
+| `-out` | Output image file (.png, .jpg, or .gif) | `out.png` |
 | `-width` | Image width in pixels | 1024 |
 | `-margin` | Margin in pixels | 48 |
 | `-pt` | Base font size (points) | 16 |
@@ -86,6 +86,12 @@ Dark theme with larger font and wider layout:
 
 ```bash
 ./md2png -in blogpost.md -out post.png -theme dark -width 1400 -pt 18
+```
+
+Render a looping GIF (palette-quantized automatically):
+
+```bash
+./md2png -in slides.md -out slides.gif
 ```
 
 Using your own fonts:

--- a/cmd/md2png/main.go
+++ b/cmd/md2png/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"flag"
+	"image/gif"
 	"image/jpeg"
 	"image/png"
 	"io"
@@ -15,7 +16,7 @@ import (
 
 func main() {
 	in := flag.String("in", "", "Input Markdown file (default: stdin if empty)")
-	out := flag.String("out", "out.png", "Output image file (.png or .jpg)")
+	out := flag.String("out", "out.png", "Output image file (.png, .jpg, or .gif)")
 	width := flag.Int("width", 1024, "Output image width in pixels")
 	margin := flag.Int("margin", 48, "Margin in pixels")
 	pt := flag.Float64("pt", 16, "Base font size in points (paragraph)")
@@ -93,6 +94,10 @@ func main() {
 		}
 	case ".jpg", ".jpeg":
 		if err := jpeg.Encode(file, img, &jpeg.Options{Quality: 92}); err != nil {
+			fatal(err)
+		}
+	case ".gif":
+		if err := gif.Encode(file, img, nil); err != nil {
 			fatal(err)
 		}
 	default:

--- a/md2png.go
+++ b/md2png.go
@@ -37,7 +37,7 @@ import (
 //  - Pure Go binary (no JS, no Python)
 //  - Reasonable rendering: headings, paragraphs, lists, code blocks, hr, blockquotes
 //  - Word wrap by width; adjustable width, margins, fonts, theme
-//  - Export PNG or JPG based on output extension
+//  - Export PNG, JPG, or GIF based on output extension
 //
 // Not a full HTML renderer; keep expectations practical.
 


### PR DESCRIPTION
## Summary
- add GIF encoding support to the CLI when the output file uses a .gif extension
- document GIF availability in the README and high-level renderer goals

## Testing
- go test -run . -count=1 -v
- go run ./cmd/md2png -in README.md -out output.png

------
https://chatgpt.com/codex/tasks/task_e_68ef4abed144832f9aa36d9d5b4f7f79