### PR TITLE
Update nightly job schedule to 6am AEST on 2nd of each month

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ on:
     # preferred heavy monthly run (quota reset strategy)
     - cron: '17 3 1 * *'
     # optional nightly lightweight checks
-    - cron: '41 2 * * *'
+    - cron: '0 20 1 * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
@@ -122,7 +122,7 @@ jobs:
               if [[ "${{ github.event.schedule }}" == "17 3 1 * *" ]]; then
                 is_monthly=true
               fi
-              if [[ "${{ github.event.schedule }}" == "41 2 * * *" ]]; then
+              if [[ "${{ github.event.schedule }}" == "0 20 1 * *" ]]; then
                 is_nightly=true
               fi
               ;;


### PR DESCRIPTION
Update nightly job schedule to 6am AEST on 2nd of each month

Changed the cron schedule from '41 2 * * *' to '0 20 1 * *' (20:00 UTC on the 1st of the month, which is 6:00 AM AEST on the 2nd) as requested. Updated the corresponding conditional check in ci.yml as well.

---
*PR created automatically by Jules for task [1355359403975605126](https://jules.google.com/task/1355359403975605126) started by @arran4*