### PR TITLE
docs: add md2view documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ echo "# Hello\nThis came from stdin!" | ./md2png -out hello.png
 `md2view` is a GUI viewer for Markdown. It supports the same flags as `md2png` for theming, fonts, width, and margins, but renders the Markdown in a zoomable, pannable desktop window instead of saving it to an image.
 
 ```bash
-./md2view -in README.md
+./md2view README.md
 ```
 
 ### Controls

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Clone and build:
 git clone https://github.com/arran4/md2png.git
 cd md2png
 go build ./cmd/md2png
+go build ./cmd/md2view
 ```
 
 Dependencies are pure Go packages:
@@ -91,6 +92,22 @@ From stdin:
 ```bash
 echo "# Hello\nThis came from stdin!" | ./md2png -out hello.png
 ```
+
+---
+
+## md2view usage
+
+`md2view` is a GUI viewer for Markdown. It supports the same flags as `md2png` for theming, fonts, width, and margins, but renders the Markdown in a zoomable, pannable desktop window instead of saving it to an image.
+
+```bash
+./md2view -in README.md
+```
+
+### Controls
+
+- **Pan/Scroll:** Left Click and Drag, Arrow Keys, or PageUp/PageDown.
+- **Zoom In/Out:** Mouse Wheel Up/Down, or `+` / `-` keys.
+- **Quit:** `ESC` or `Q`.
 
 ---
 


### PR DESCRIPTION
This PR adds missing documentation for the `md2view` GUI tool directly to the repository's `README.md`. It explains how to build the tool, execute it via the CLI, and interacts with the rendered markdown view via mouse and keyboard commands.

---
*PR created automatically by Jules for task [11106907725313379119](https://jules.google.com/task/11106907725313379119) started by @arran4*