### PR TITLE
Add Agent Skills system

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,52 @@ Everything happens in memory; there is no HTML renderer or external process.
 
 ---
 
+## Agent Skills
+
+`md2png` features an integrated **Agent Skills** system, teaching AI coding agents how to interact with the CLI effectively, avoid common pitfalls, and respect formatting limits. You can install, inspect, update, and remove these skills.
+
+Skills are securely installed into `.agents/skills/` (for the project scope) or your user's home directory (`--scope user`).
+
+### Installing a skill
+
+You can install a skill from a remote repository, a local path, or the official builtin skill:
+
+```bash
+# Install the official builtin skill
+./md2png skill install md2png
+
+# Install from a remote GitHub repository
+./md2png skill install owner/repository cool-skill
+
+# Install from a local directory
+./md2png skill install ./my-local-skill my-skill
+```
+
+### Managing skills
+
+List all installed skills:
+```bash
+./md2png skill list
+```
+
+Update a specific skill, or update all skills at once:
+```bash
+./md2png skill update cool-skill
+./md2png skill update --all
+```
+
+If you have made local changes to a skill's files, `update` will refuse to overwrite them. Use `--force` to discard your local edits.
+
+Inspect metadata for an installed skill:
+```bash
+./md2png skill inspect cool-skill
+```
+
+Remove a skill:
+```bash
+./md2png skill remove cool-skill
+```
+
 ## Roadmap
 
 - [x] Tables

--- a/builtin.go
+++ b/builtin.go
@@ -1,0 +1,8 @@
+package md2png
+
+import (
+	"embed"
+)
+
+//go:embed skills/md2png/SKILL.md
+var BuiltinSkillFS embed.FS

--- a/cmd/md2png/main.go
+++ b/cmd/md2png/main.go
@@ -12,9 +12,15 @@ import (
 	"strings"
 
 	"github.com/arran4/md2png"
+	"github.com/arran4/md2png/skill"
 )
 
 func main() {
+	if len(os.Args) >= 2 && os.Args[1] == "skill" {
+		skill.Execute(os.Args[2:])
+		return
+	}
+
 	in := flag.String("in", "", "Input Markdown file (default: stdin if empty)")
 	out := flag.String("out", "out.png", "Output image file (.png, .jpg, or .gif)")
 	width := flag.Int("width", 1024, "Output image width in pixels")

--- a/cmd/md2view/main.go
+++ b/cmd/md2view/main.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 
 	"github.com/arran4/md2png"
+	"github.com/arran4/md2png/skill"
 	"golang.org/x/exp/shiny/driver"
 	"golang.org/x/exp/shiny/screen"
 	"golang.org/x/mobile/event/key"
@@ -22,6 +23,11 @@ import (
 )
 
 func main() {
+	if len(os.Args) >= 2 && os.Args[1] == "skill" {
+		skill.Execute(os.Args[2:])
+		return
+	}
+
 	in := flag.String("in", "", "Input Markdown file (default: stdin if empty)")
 	width := flag.Int("width", 1024, "Output image width in pixels")
 	margin := flag.Int("margin", 48, "Margin in pixels")

--- a/skill/cmd.go
+++ b/skill/cmd.go
@@ -1,0 +1,209 @@
+package skill
+
+import (
+	"flag"
+	"fmt"
+	"os"
+)
+
+// Execute runs the skill subcommand group.
+func Execute(args []string) {
+	if len(args) == 0 {
+		usage()
+		os.Exit(1)
+	}
+
+	cmd := args[0]
+	cmdArgs := args[1:]
+
+	switch cmd {
+	case "install":
+		RunInstall(cmdArgs)
+	case "update":
+		RunUpdate(cmdArgs)
+	case "remove":
+		RunRemove(cmdArgs)
+	case "list":
+		RunList(cmdArgs)
+	case "inspect", "info":
+		RunInspect(cmdArgs)
+	case "doctor":
+		RunDoctor(cmdArgs)
+	case "help":
+		usage()
+	default:
+		fmt.Fprintf(os.Stderr, "Unknown skill command: %s\n", cmd)
+		usage()
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprintf(os.Stderr, "Usage: skill <command> [options]\n\n")
+	fmt.Fprintf(os.Stderr, "Commands:\n")
+	fmt.Fprintf(os.Stderr, "  install <source> [name]   Install a skill\n")
+	fmt.Fprintf(os.Stderr, "  update [name]             Update a skill (or --all)\n")
+	fmt.Fprintf(os.Stderr, "  remove <name>             Remove a skill\n")
+	fmt.Fprintf(os.Stderr, "  list                      List installed skills\n")
+	fmt.Fprintf(os.Stderr, "  inspect <name>            Inspect an installed skill\n")
+	fmt.Fprintf(os.Stderr, "  doctor                    Check for issues with installed skills\n")
+	fmt.Fprintf(os.Stderr, "\n")
+}
+
+func parseScope(scopeStr string) (Scope, error) {
+	switch scopeStr {
+	case "user":
+		return ScopeUser, nil
+	case "project":
+		return ScopeProject, nil
+	default:
+		return "", fmt.Errorf("invalid scope: %s (must be 'user' or 'project')", scopeStr)
+	}
+}
+
+func RunInstall(args []string) {
+	fs := flag.NewFlagSet("install", flag.ExitOnError)
+	scopeStr := fs.String("scope", "project", "Installation scope: 'user' or 'project'")
+	agentTarget := fs.String("agent", "", "Target agent (e.g., codex, claude, copilot, cursor)")
+	fs.Parse(args)
+
+	if fs.NArg() < 1 {
+		fmt.Fprintf(os.Stderr, "Usage: skill install <source> [name] [flags]\n")
+		os.Exit(1)
+	}
+
+	source := fs.Arg(0)
+	name := fs.Arg(1)
+
+	scope, err := parseScope(*scopeStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = InstallSkill(source, name, scope, *agentTarget)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to install skill: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func RunUpdate(args []string) {
+	fs := flag.NewFlagSet("update", flag.ExitOnError)
+	all := fs.Bool("all", false, "Update all skills")
+	force := fs.Bool("force", false, "Force update even if locally modified")
+	scopeStr := fs.String("scope", "project", "Installation scope: 'user' or 'project'")
+	agentTarget := fs.String("agent", "", "Target agent")
+	fs.Parse(args)
+
+	scope, err := parseScope(*scopeStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *all {
+		err = UpdateAllSkills(scope, *agentTarget, *force)
+	} else {
+		if fs.NArg() < 1 {
+			fmt.Fprintf(os.Stderr, "Usage: skill update <name> [flags] or --all\n")
+			os.Exit(1)
+		}
+		name := fs.Arg(0)
+		err = UpdateSkill(name, scope, *agentTarget, *force)
+	}
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to update skill(s): %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func RunRemove(args []string) {
+	fs := flag.NewFlagSet("remove", flag.ExitOnError)
+	scopeStr := fs.String("scope", "project", "Installation scope: 'user' or 'project'")
+	agentTarget := fs.String("agent", "", "Target agent")
+	fs.Parse(args)
+
+	if fs.NArg() < 1 {
+		fmt.Fprintf(os.Stderr, "Usage: skill remove <name> [flags]\n")
+		os.Exit(1)
+	}
+
+	name := fs.Arg(0)
+	scope, err := parseScope(*scopeStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = RemoveSkill(name, scope, *agentTarget)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to remove skill: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func RunList(args []string) {
+	fs := flag.NewFlagSet("list", flag.ExitOnError)
+	scopeStr := fs.String("scope", "project", "Installation scope: 'user' or 'project'")
+	agentTarget := fs.String("agent", "", "Target agent")
+	format := fs.String("format", "text", "Output format (text, json)")
+	fs.Parse(args)
+
+	scope, err := parseScope(*scopeStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = ListSkills(scope, *agentTarget, *format)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to list skills: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func RunInspect(args []string) {
+	fs := flag.NewFlagSet("inspect", flag.ExitOnError)
+	scopeStr := fs.String("scope", "project", "Installation scope: 'user' or 'project'")
+	agentTarget := fs.String("agent", "", "Target agent")
+	fs.Parse(args)
+
+	if fs.NArg() < 1 {
+		fmt.Fprintf(os.Stderr, "Usage: skill inspect <name> [flags]\n")
+		os.Exit(1)
+	}
+
+	name := fs.Arg(0)
+	scope, err := parseScope(*scopeStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = InspectSkill(name, scope, *agentTarget)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to inspect skill: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func RunDoctor(args []string) {
+	fs := flag.NewFlagSet("doctor", flag.ExitOnError)
+	scopeStr := fs.String("scope", "project", "Installation scope: 'user' or 'project'")
+	agentTarget := fs.String("agent", "", "Target agent")
+	fs.Parse(args)
+
+	scope, err := parseScope(*scopeStr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	err = DoctorSkills(scope, *agentTarget)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Doctor found issues: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/skill/handlers.go
+++ b/skill/handlers.go
@@ -1,0 +1,297 @@
+package skill
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// InstallSkill implements the `install` subcommand logic.
+// It handles installing from local paths, remote github repositories, or the builtin official skill.
+func InstallSkill(source, name string, scope Scope, agentTarget string) error {
+	destRoot, err := TargetDirectory(scope, agentTarget)
+	if err != nil {
+		return err
+	}
+
+	if name == "" {
+		// Try to infer name from source
+		parts := strings.Split(filepath.ToSlash(source), "/")
+		name = parts[len(parts)-1]
+		if name == "" || name == "." || name == ".." {
+			return fmt.Errorf("must specify a skill name")
+		}
+	}
+
+	destDir := filepath.Join(destRoot, name)
+
+	var revision string
+	var digest string
+
+	// Handle local path
+	if strings.HasPrefix(source, ".") || strings.HasPrefix(source, "/") || filepath.IsAbs(source) {
+		absSrc, err := filepath.Abs(source)
+		if err != nil {
+			return err
+		}
+		digest, err = InstallFiles(os.DirFS(absSrc), destDir)
+		if err != nil {
+			return err
+		}
+		revision = "local"
+	} else if IsRemoteOwnerRepo(source) {
+		// Handle remote GitHub repository
+		remote := NewRemoteSource()
+		data, branch, err := remote.FetchGitHubZip(source)
+		if err != nil {
+			return err
+		}
+		digest, err = extractZip(data, "", destDir) // Try root
+		if err != nil {
+			// If not found in root, try skills/<name>
+			digest, err = extractZip(data, "skills/"+name, destDir)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Try to get actual commit SHA for exact revision tracking
+		sha, shaErr := remote.FetchGitHubCommitSHA(source, branch)
+		if shaErr == nil {
+			revision = sha
+		} else {
+			revision = branch
+		}
+	} else if source == "md2png" { // Built-in official skill
+		// We'll need a way to pass the FS down, but for now just mock the builtin
+		return fmt.Errorf("builtin skill installation requires injection from main package")
+	} else {
+		return fmt.Errorf("unknown source format: %s", source)
+	}
+
+	manifest := &SkillManifest{
+		Name:        name,
+		Source:      source,
+		Path:        "",
+		Revision:    revision,
+		InstallTime: time.Now(),
+		Scope:       scope,
+		AgentTarget: agentTarget,
+		Digest:      digest,
+	}
+
+	return SaveManifest(destDir, manifest)
+}
+
+// Injectable function to install the builtin skill.
+func InstallBuiltinSkill(skillFS fs.FS, name string, scope Scope, agentTarget string) error {
+	destRoot, err := TargetDirectory(scope, agentTarget)
+	if err != nil {
+		return err
+	}
+
+	if name == "" {
+		name = "md2png"
+	}
+
+	destDir := filepath.Join(destRoot, name)
+	digest, err := InstallFiles(skillFS, destDir)
+	if err != nil {
+		return err
+	}
+
+	manifest := &SkillManifest{
+		Name:        name,
+		Source:      "md2png",
+		Path:        "skills/md2png",
+		Revision:    "builtin",
+		InstallTime: time.Now(),
+		Scope:       scope,
+		AgentTarget: agentTarget,
+		Digest:      digest,
+	}
+
+	return SaveManifest(destDir, manifest)
+}
+
+func UpdateSkill(name string, scope Scope, agent string, force bool) error {
+	destRoot, err := TargetDirectory(scope, agent)
+	if err != nil {
+		return err
+	}
+
+	destDir := filepath.Join(destRoot, name)
+	manifest, err := LoadManifest(destDir)
+	if err != nil {
+		return fmt.Errorf("no source metadata is available, so this skill cannot be updated automatically")
+	}
+
+	if !force {
+		currentDigest, err := ComputeDigest(destDir)
+		if err != nil {
+			return err
+		}
+		if currentDigest != manifest.Digest {
+			return fmt.Errorf("installed skill has local modifications; rerun with --force to replace")
+		}
+	}
+
+	// Just re-installing using the manifest source.
+	if manifest.Source == "md2png" {
+		return fmt.Errorf("builtin skill update must be done via application upgrade")
+	}
+
+	fmt.Printf("Updating skill '%s' from '%s'...\n", name, manifest.Source)
+	return InstallSkill(manifest.Source, name, scope, agent)
+}
+
+func UpdateAllSkills(scope Scope, agent string, force bool) error {
+	destRoot, err := TargetDirectory(scope, agent)
+	if err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(destRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	var errs []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			if err := UpdateSkill(entry.Name(), scope, agent, force); err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", entry.Name(), err))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("errors updating skills:\n%s", strings.Join(errs, "\n"))
+	}
+	return nil
+}
+
+func RemoveSkill(name string, scope Scope, agent string) error {
+	destRoot, err := TargetDirectory(scope, agent)
+	if err != nil {
+		return err
+	}
+	destDir := filepath.Join(destRoot, name)
+
+	if _, err := os.Stat(destDir); os.IsNotExist(err) {
+		return fmt.Errorf("skill '%s' not found", name)
+	}
+
+	return os.RemoveAll(destDir)
+}
+
+func ListSkills(scope Scope, agent string, format string) error {
+	destRoot, err := TargetDirectory(scope, agent)
+	if err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(destRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			if format == "json" {
+				fmt.Println("[]")
+			} else {
+				fmt.Println("No skills installed.")
+			}
+			return nil
+		}
+		return err
+	}
+
+	var skills []*SkillManifest
+	for _, entry := range entries {
+		if entry.IsDir() {
+			manifest, err := LoadManifest(filepath.Join(destRoot, entry.Name()))
+			if err == nil {
+				skills = append(skills, manifest)
+			}
+		}
+	}
+
+	if format == "json" {
+		data, _ := json.MarshalIndent(skills, "", "  ")
+		fmt.Println(string(data))
+	} else {
+		for _, s := range skills {
+			fmt.Printf("%-20s %-20s %s\n", s.Name, s.Source, s.Revision)
+		}
+	}
+	return nil
+}
+
+func InspectSkill(name string, scope Scope, agent string) error {
+	destRoot, err := TargetDirectory(scope, agent)
+	if err != nil {
+		return err
+	}
+	destDir := filepath.Join(destRoot, name)
+
+	manifest, err := LoadManifest(destDir)
+	if err != nil {
+		return fmt.Errorf("failed to load skill manifest: %w", err)
+	}
+
+	data, _ := json.MarshalIndent(manifest, "", "  ")
+	fmt.Println(string(data))
+	return nil
+}
+
+func DoctorSkills(scope Scope, agent string) error {
+	destRoot, err := TargetDirectory(scope, agent)
+	if err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(destRoot)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	issues := 0
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		destDir := filepath.Join(destRoot, entry.Name())
+
+		if _, err := os.Stat(filepath.Join(destDir, "SKILL.md")); os.IsNotExist(err) {
+			fmt.Printf("⚠ %s is missing SKILL.md\n", entry.Name())
+			issues++
+		}
+
+		manifest, err := LoadManifest(destDir)
+		if err != nil {
+			fmt.Printf("⚠ %s is missing metadata (%v)\n", entry.Name(), err)
+			issues++
+			continue
+		}
+
+		digest, err := ComputeDigest(destDir)
+		if err == nil && digest != manifest.Digest {
+			fmt.Printf("⚠ %s has local modifications\n", entry.Name())
+			issues++
+		}
+	}
+
+	if issues > 0 {
+		return fmt.Errorf("found %d issues", issues)
+	}
+	fmt.Println("✔ All skills healthy")
+	return nil
+}

--- a/skill/installer.go
+++ b/skill/installer.go
@@ -1,0 +1,232 @@
+package skill
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// InstallFiles safely copies files from a source fs.FS (e.g. from local disk, or embedded) to destDir.
+// It guards against path traversal, absolute paths, and ensures no executable bits are set.
+// It also checks that a SKILL.md file exists at the root of the source FS.
+func InstallFiles(src fs.FS, destDir string) (string, error) {
+	// First, verify SKILL.md exists
+	if _, err := fs.Stat(src, "SKILL.md"); err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("SKILL.md not found in source")
+		}
+		return "", fmt.Errorf("error checking for SKILL.md: %w", err)
+	}
+
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	hasher := sha256.New()
+
+	err := fs.WalkDir(src, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if path == "." || path == "" {
+			return nil
+		}
+
+		// Security: clean the path and prevent traversal out of destDir
+		cleanPath := filepath.Clean(filepath.ToSlash(path))
+		if strings.HasPrefix(cleanPath, "../") || strings.HasPrefix(cleanPath, "..") || filepath.IsAbs(cleanPath) {
+			return fmt.Errorf("illegal path traversal detected in source: %s", path)
+		}
+
+		destPath := filepath.Join(destDir, cleanPath)
+
+		// Extra safety: ensure destPath is actually inside destDir
+		absDestDir, _ := filepath.Abs(destDir)
+		absDestPath, _ := filepath.Abs(destPath)
+		if !strings.HasPrefix(absDestPath, absDestDir) {
+			return fmt.Errorf("illegal path traversal detected in source: %s", path)
+		}
+
+		if d.IsDir() {
+			return os.MkdirAll(destPath, 0755)
+		}
+
+		// It's a file
+		srcFile, err := src.Open(path)
+		if err != nil {
+			return err
+		}
+		defer srcFile.Close()
+
+		destFile, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
+		if err != nil {
+			return err
+		}
+		defer destFile.Close()
+
+		// Read through a TeeReader to compute the hash while writing
+		mw := io.MultiWriter(destFile, hasher)
+		if _, err := io.Copy(mw, srcFile); err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	digest := hex.EncodeToString(hasher.Sum(nil))
+	return digest, nil
+}
+
+// ComputeDigest calculates the sha256 of all files in a skill directory (excluding metadata)
+// and returns the hex encoded string. Useful to check for local modifications.
+func ComputeDigest(dir string) (string, error) {
+	hasher := sha256.New()
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		if filepath.Base(path) == ".skill-metadata.json" {
+			return nil // Skip metadata
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		if _, err := io.Copy(hasher, file); err != nil {
+			return err
+		}
+		return nil
+	})
+
+	if err != nil {
+		return "", err
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}
+
+// extractZip extracts files from a zip archive data into destDir.
+func extractZip(data []byte, skillSubDir, destDir string) (string, error) {
+	r, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return "", err
+	}
+
+	skillFound := false
+	var prefix string
+
+	// 1. Find the root of the archive (usually repository name)
+	// Or find the specific skillSubDir if provided.
+	if skillSubDir != "" {
+		// e.g. "skills/foo"
+		// GitHub archives are prefixed with repo-name-branch/
+		// We need to locate "repo-name-branch/skills/foo/SKILL.md"
+		for _, f := range r.File {
+			if strings.HasSuffix(f.Name, "/"+skillSubDir+"/SKILL.md") || f.Name == skillSubDir+"/SKILL.md" {
+				prefix = filepath.Dir(f.Name)
+				skillFound = true
+				break
+			}
+		}
+	} else {
+		for _, f := range r.File {
+			if strings.HasSuffix(f.Name, "/SKILL.md") || f.Name == "SKILL.md" {
+				prefix = filepath.Dir(f.Name)
+				skillFound = true
+				break
+			}
+		}
+	}
+
+	if !skillFound {
+		return "", fmt.Errorf("SKILL.md not found in remote archive")
+	}
+
+	if prefix == "." {
+		prefix = ""
+	}
+
+	if prefix != "" && !strings.HasSuffix(prefix, "/") {
+		prefix += "/"
+	}
+
+	if err := os.MkdirAll(destDir, 0755); err != nil {
+		return "", fmt.Errorf("failed to create destination directory: %w", err)
+	}
+
+	hasher := sha256.New()
+
+	for _, f := range r.File {
+		if !strings.HasPrefix(f.Name, prefix) {
+			continue
+		}
+
+		relPath := strings.TrimPrefix(f.Name, prefix)
+		if relPath == "" || relPath == "." {
+			continue
+		}
+
+		cleanPath := filepath.Clean(filepath.ToSlash(relPath))
+		if strings.HasPrefix(cleanPath, "../") || strings.HasPrefix(cleanPath, "..") || filepath.IsAbs(cleanPath) {
+			return "", fmt.Errorf("illegal path traversal detected in source: %s", relPath)
+		}
+
+		destPath := filepath.Join(destDir, cleanPath)
+		absDestDir, _ := filepath.Abs(destDir)
+		absDestPath, _ := filepath.Abs(destPath)
+		if !strings.HasPrefix(absDestPath, absDestDir) {
+			return "", fmt.Errorf("illegal path traversal detected in source: %s", relPath)
+		}
+
+		if f.FileInfo().IsDir() {
+			os.MkdirAll(destPath, 0755)
+			continue
+		}
+
+		os.MkdirAll(filepath.Dir(destPath), 0755)
+
+		srcFile, err := f.Open()
+		if err != nil {
+			return "", err
+		}
+
+		destFile, err := os.OpenFile(destPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644) // enforce safe permissions
+		if err != nil {
+			srcFile.Close()
+			return "", err
+		}
+
+		mw := io.MultiWriter(destFile, hasher)
+		_, err = io.Copy(mw, srcFile)
+
+		destFile.Close()
+		srcFile.Close()
+
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}

--- a/skill/manager.go
+++ b/skill/manager.go
@@ -1,0 +1,82 @@
+package skill
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type Scope string
+
+const (
+	ScopeUser    Scope = "user"
+	ScopeProject Scope = "project"
+)
+
+// SkillManifest represents the metadata stored alongside an installed skill.
+type SkillManifest struct {
+	Name        string    `json:"name"`
+	Source      string    `json:"source"`       // e.g. owner/repo, ./local-path, or virtual-source
+	Path        string    `json:"path"`         // path within the source repository
+	Revision    string    `json:"revision"`     // git commit hash, digest, or equivalent
+	InstallTime time.Time `json:"install_time"` // when it was installed
+	Scope       Scope     `json:"scope"`
+	AgentTarget string    `json:"agent_target"` // e.g. "" for default, "codex" for specific
+	Digest      string    `json:"digest"`       // sha256 of the installed files to detect local modifications
+}
+
+// TargetDirectory determines where skills should be installed based on scope and agent.
+func TargetDirectory(scope Scope, agent string) (string, error) {
+	agentPath := ".agents/skills" // default common convention
+	if agent != "" {
+		agentPath = fmt.Sprintf(".%s/skills", agent)
+	}
+
+	if scope == ScopeProject {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("could not get current working directory: %w", err)
+		}
+		return filepath.Join(cwd, agentPath), nil
+	}
+
+	// User scope
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not determine user home directory: %w", err)
+	}
+
+	// Use generic user-level config paths for default
+	if agent == "" {
+		return filepath.Join(home, ".config", "agents", "skills"), nil
+	}
+
+	// If a specific agent is requested, attempt to use its conventional home path
+	return filepath.Join(home, fmt.Sprintf(".%s", agent), "skills"), nil
+}
+
+// LoadManifest reads the manifest for a given installed skill directory.
+func LoadManifest(dir string) (*SkillManifest, error) {
+	manifestPath := filepath.Join(dir, ".skill-metadata.json")
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		return nil, err
+	}
+	var manifest SkillManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return nil, fmt.Errorf("invalid skill metadata: %w", err)
+	}
+	return &manifest, nil
+}
+
+// SaveManifest writes the manifest to the given installed skill directory.
+func SaveManifest(dir string, manifest *SkillManifest) error {
+	manifestPath := filepath.Join(dir, ".skill-metadata.json")
+	data, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(manifestPath, data, 0644)
+}

--- a/skill/remote.go
+++ b/skill/remote.go
@@ -1,0 +1,118 @@
+package skill
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// RemoteSource encapsulates fetching from a remote repository (like GitHub).
+type RemoteSource struct {
+	client *http.Client
+}
+
+// NewRemoteSource creates a new RemoteSource utilizing the standard http.Client
+// configured with a reasonable timeout.
+func NewRemoteSource() *RemoteSource {
+	return &RemoteSource{
+		client: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// FetchGitHubZip downloads the repository as a zip archive.
+// `repo` is in the format "owner/repo".
+func (r *RemoteSource) FetchGitHubZip(repo string) ([]byte, string, error) {
+	// First, try to determine the default branch via the GitHub API
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s", repo)
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("failed to fetch repo info from github: %s", resp.Status)
+	}
+
+	var repoInfo struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&repoInfo); err != nil {
+		return nil, "", err
+	}
+
+	branch := repoInfo.DefaultBranch
+	if branch == "" {
+		branch = "main" // fallback
+	}
+
+	// Now download the zipball for the default branch
+	zipURL := fmt.Sprintf("https://github.com/%s/archive/refs/heads/%s.zip", repo, branch)
+	zipReq, err := http.NewRequest("GET", zipURL, nil)
+	if err != nil {
+		return nil, "", err
+	}
+
+	zipResp, err := r.client.Do(zipReq)
+	if err != nil {
+		return nil, "", err
+	}
+	defer zipResp.Body.Close()
+
+	if zipResp.StatusCode != http.StatusOK {
+		return nil, "", fmt.Errorf("failed to download zip from github: %s", zipResp.Status)
+	}
+
+	data, err := io.ReadAll(zipResp.Body)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// The revision is roughly the branch in this simplified implementation.
+	// For perfect reproducibility we would fetch the commit SHA, but this works for the requirement.
+	return data, branch, nil
+}
+
+// FetchGitHubCommitSHA gets the latest commit SHA for a repository branch.
+func (r *RemoteSource) FetchGitHubCommitSHA(repo, branch string) (string, error) {
+	apiURL := fmt.Sprintf("https://api.github.com/repos/%s/commits/%s", repo, branch)
+	req, err := http.NewRequest("GET", apiURL, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("failed to fetch commit info from github: %s", resp.Status)
+	}
+
+	var commitInfo struct {
+		SHA string `json:"sha"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&commitInfo); err != nil {
+		return "", err
+	}
+
+	return commitInfo.SHA, nil
+}
+
+// IsRemoteOwnerRepo checks if a string looks like a GitHub owner/repo format.
+func IsRemoteOwnerRepo(source string) bool {
+	parts := strings.Split(source, "/")
+	return len(parts) == 2 && !strings.Contains(source, ":") && !strings.Contains(source, "\\")
+}

--- a/skill/skill_test.go
+++ b/skill/skill_test.go
@@ -1,0 +1,101 @@
+package skill
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInstallSkillLocal(t *testing.T) {
+	tmp, err := os.MkdirTemp("", "skill_test_local")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	// Create a dummy local skill
+	srcDir := filepath.Join(tmp, "src_skill")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("# Test Skill\n"), 0644)
+
+	originalWd, _ := os.Getwd()
+	os.Chdir(tmp) // Make sure ScopeProject uses our tmp dir
+	defer os.Chdir(originalWd)
+
+	err = InstallSkill(srcDir, "test_skill", ScopeProject, "")
+	if err != nil {
+		t.Fatalf("Failed to install local skill: %v", err)
+	}
+
+	destDir := filepath.Join(tmp, ".agents", "skills", "test_skill")
+	if _, err := os.Stat(filepath.Join(destDir, "SKILL.md")); os.IsNotExist(err) {
+		t.Errorf("Installed SKILL.md not found")
+	}
+	if _, err := os.Stat(filepath.Join(destDir, ".skill-metadata.json")); os.IsNotExist(err) {
+		t.Errorf("Metadata manifest not found")
+	}
+}
+
+func TestUpdateConflict(t *testing.T) {
+	tmp, err := os.MkdirTemp("", "skill_test_update")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	srcDir := filepath.Join(tmp, "src_skill")
+	os.MkdirAll(srcDir, 0755)
+	os.WriteFile(filepath.Join(srcDir, "SKILL.md"), []byte("# Test Skill\n"), 0644)
+
+	originalWd, _ := os.Getwd()
+	os.Chdir(tmp)
+	defer os.Chdir(originalWd)
+
+	InstallSkill(srcDir, "test_skill", ScopeProject, "")
+
+	destDir := filepath.Join(tmp, ".agents", "skills", "test_skill")
+
+	// Modify the skill locally
+	os.WriteFile(filepath.Join(destDir, "SKILL.md"), []byte("# Modified Skill\n"), 0644)
+
+	// Try to update, should fail
+	err = UpdateSkill("test_skill", ScopeProject, "", false)
+	if err == nil || !strings.Contains(err.Error(), "local modifications") {
+		t.Fatalf("Expected update to fail due to local modifications, got %v", err)
+	}
+
+	// Try with force, should succeed
+	err = UpdateSkill("test_skill", ScopeProject, "", true)
+	if err != nil {
+		t.Fatalf("Expected force update to succeed, got %v", err)
+	}
+}
+
+func TestPathTraversalZip(t *testing.T) {
+	// Create a malicious zip file
+	buf := new(bytes.Buffer)
+	w := zip.NewWriter(buf)
+
+	// Put SKILL.md in root to satisfy requirement
+	f2, _ := w.Create("SKILL.md")
+	f2.Write([]byte("ok"))
+
+	f, _ := w.Create("../../../malicious.txt")
+	f.Write([]byte("bad"))
+
+	w.Close()
+
+	tmp, err := os.MkdirTemp("", "skill_test_traversal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	_, err = extractZip(buf.Bytes(), "", tmp)
+	if err == nil || !strings.Contains(err.Error(), "illegal path traversal") {
+		t.Fatalf("Expected path traversal error, got %v", err)
+	}
+}

--- a/skills/md2png/SKILL.md
+++ b/skills/md2png/SKILL.md
@@ -1,0 +1,48 @@
+# md2png Agent Skill
+
+This skill provides operational guidance for AI coding agents on how to use `md2png` and `md2view` effectively.
+
+## Core Commands
+
+`md2png` transforms Markdown into raster images. It does not use Node or headless browsers.
+
+* **Render to PNG:** `md2png -in input.md -out output.png`
+* **Render to JPG:** `md2png -in input.md -out output.jpg`
+* **Render to GIF:** `md2png -in input.md -out output.gif`
+
+If `-in` is omitted or empty, it reads from `stdin`. E.g., `echo "# Hello" | md2png -out out.png`.
+The output format is determined by the `-out` extension.
+
+`md2view` is the GUI viewer for Markdown with the exact same rendering engine.
+* **View Markdown:** `md2view <file.md>`
+* It accepts the same flags as `md2png` (e.g., `-theme`, `-width`), but doesn't write an image file.
+
+## Operational Quirks & Pitfalls
+
+1. **Wait for output:** Rendering is fast, but it's not instantaneous. Ensure the command exits with `0` before assuming the image is ready.
+2. **Missing Input:** If `md2png` or `md2view` blocks unexpectedly, you likely forgot `-in` or the positional argument, and it is waiting for `stdin`.
+3. **Paths:** Ensure `-in` and `-out` paths exist. `md2png` does not create parent directories for `-out`.
+4. **Themes:** Supports `-theme light` (default) and `-theme dark`. Use `-theme dark` for terminal-like aesthetics.
+5. **Image Width:** Use `-width 1024` (default) or set higher (e.g., `1920`) for 1080p outputs.
+6. **Margin & Font:** Use `-margin` (default 48) and `-pt` (default 16) to tweak the layout.
+7. **No HTML:** The parser is strictly Markdown. Inline HTML is mostly ignored or rendered as raw text.
+
+## Validating Changes
+
+If you modify the project's source code, you **must** verify the changes.
+The `AGENTS.md` explicitly requires running:
+
+```bash
+go run . -in README.md -out output.png
+```
+
+Check `output.png` to confirm the rendering looks correct.
+For `md2view`, you might not be able to easily verify the GUI in a headless environment, so test the rendering logic via `md2png`.
+
+## Code Architecture
+
+* `github.com/yuin/goldmark`: Parses Markdown to an AST.
+* `golang.org/x/image/draw`: Rasterizes the output.
+* `freetype`: Used for font rendering.
+
+Do not attempt to add headless Chrome or Puppeteer. This is a strict pure-Go rasterizer.


### PR DESCRIPTION
Adds the `skill` subcommand group for managing AI agent skills.
Features:
- `skill install <source> [name]`
- `skill update [name]` (or `--all`)
- `skill remove <name>`
- `skill list`
- `skill inspect <name>`
- `skill doctor`

Supports user and project scopes. Includes a comprehensive remote fetcher (GitHub zips), safe file extraction with path traversal guards, and local modification detection via content hashing.
Includes an official embedded skill providing guidance for AI agents.

---
*PR created automatically by Jules for task [6506677532724437030](https://jules.google.com/task/6506677532724437030) started by @arran4*