### PR TITLE
Fix GoReleaser error regarding different binary counts per platform

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -61,6 +61,7 @@ builds:
 
 archives:
   - id: release-archives
+    allow_different_binary_count: true
     builds:
       - md2png
       - md2view


### PR DESCRIPTION
The `.goreleaser.yaml` has been updated with `allow_different_binary_count: true` to support generating archives with different binary counts based on the platform. This resolves the GoReleaser error: `archive has different count of binaries for each platform`.

---
*PR created automatically by Jules for task [18216689034871164338](https://jules.google.com/task/18216689034871164338) started by @arran4*