### PR TITLE
Fix silent markdown clipping by implementing dynamic canvas growth

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Requires Go 1.22 or newer.
 | `-fontmono` | Monospace font TTF path | built-in Go Mono |
 | `-footnote-links` | Emit link targets as numbered footnotes | `true` |
 | `-footnote-images` | Emit image targets as numbered footnotes | `false` |
-| `-max-height` | Maximum output height in pixels (0 for unlimited) | 32768 |
+| `-max-height` | Maximum output height in pixels (0 for default) | 32768 |
 
 ### Examples
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Requires Go 1.22 or newer.
 | `-fontmono` | Monospace font TTF path | built-in Go Mono |
 | `-footnote-links` | Emit link targets as numbered footnotes | `true` |
 | `-footnote-images` | Emit image targets as numbered footnotes | `false` |
+| `-max-height` | Maximum output height in pixels (0 for unlimited) | 32768 |
 
 ### Examples
 
@@ -141,7 +142,7 @@ func main() {
 }
 ```
 
-`RenderOptions` exposes the same knobs as the CLI. Set custom dimensions, swap themes, toggle link or image footnotes, or pass a font set created with `md2png.LoadFonts`.
+`RenderOptions` exposes the same knobs as the CLI. Set custom dimensions, limits (`MaxHeight`), swap themes, toggle link or image footnotes, or pass a font set created with `md2png.LoadFonts`.
 
 ---
 

--- a/cmd/md2png/main.go
+++ b/cmd/md2png/main.go
@@ -26,6 +26,7 @@ func main() {
 	fontMono := flag.String("fontmono", "", "Path to TTF for mono/code (optional; default Go Mono)")
 	footnoteLinks := flag.Bool("footnote-links", true, "Add footnotes for link destinations")
 	footnoteImages := flag.Bool("footnote-images", false, "Add footnotes for image destinations")
+	maxHeight := flag.Int("max-height", 32768, "Maximum output height in pixels (0 for unlimited)")
 	flag.Parse()
 
 	th, err := md2png.ThemeByName(*theme)
@@ -75,6 +76,7 @@ func main() {
 		LinkFootnotes:  footnoteLinks,
 		ImageFootnotes: footnoteImages,
 		BaseDir:        baseDir,
+		MaxHeight:      *maxHeight,
 	})
 	if err != nil {
 		fatal(err)

--- a/cmd/md2png/main.go
+++ b/cmd/md2png/main.go
@@ -26,7 +26,7 @@ func main() {
 	fontMono := flag.String("fontmono", "", "Path to TTF for mono/code (optional; default Go Mono)")
 	footnoteLinks := flag.Bool("footnote-links", true, "Add footnotes for link destinations")
 	footnoteImages := flag.Bool("footnote-images", false, "Add footnotes for image destinations")
-	maxHeight := flag.Int("max-height", 32768, "Maximum output height in pixels (0 for unlimited)")
+	maxHeight := flag.Int("max-height", 32768, "Maximum output height in pixels (0 for default)")
 	flag.Parse()
 
 	th, err := md2png.ThemeByName(*theme)

--- a/cmd/md2view/main.go
+++ b/cmd/md2view/main.go
@@ -32,7 +32,7 @@ func main() {
 	fontMono := flag.String("fontmono", "", "Path to TTF for mono/code (optional; default Go Mono)")
 	footnoteLinks := flag.Bool("footnote-links", true, "Add footnotes for link destinations")
 	footnoteImages := flag.Bool("footnote-images", false, "Add footnotes for image destinations")
-	maxHeight := flag.Int("max-height", 32768, "Maximum output height in pixels (0 for unlimited)")
+	maxHeight := flag.Int("max-height", 32768, "Maximum output height in pixels (0 for default)")
 	flag.Parse()
 
 	th, err := md2png.ThemeByName(*theme)

--- a/cmd/md2view/main.go
+++ b/cmd/md2view/main.go
@@ -12,12 +12,12 @@ import (
 	"github.com/arran4/md2png"
 	"golang.org/x/exp/shiny/driver"
 	"golang.org/x/exp/shiny/screen"
+	xdraw "golang.org/x/image/draw"
 	"golang.org/x/mobile/event/key"
 	"golang.org/x/mobile/event/lifecycle"
 	"golang.org/x/mobile/event/mouse"
 	"golang.org/x/mobile/event/paint"
 	"golang.org/x/mobile/event/size"
-	xdraw "golang.org/x/image/draw"
 	"image/draw"
 )
 
@@ -32,6 +32,7 @@ func main() {
 	fontMono := flag.String("fontmono", "", "Path to TTF for mono/code (optional; default Go Mono)")
 	footnoteLinks := flag.Bool("footnote-links", true, "Add footnotes for link destinations")
 	footnoteImages := flag.Bool("footnote-images", false, "Add footnotes for image destinations")
+	maxHeight := flag.Int("max-height", 32768, "Maximum output height in pixels (0 for unlimited)")
 	flag.Parse()
 
 	th, err := md2png.ThemeByName(*theme)
@@ -92,6 +93,7 @@ func main() {
 		LinkFootnotes:  footnoteLinks,
 		ImageFootnotes: footnoteImages,
 		BaseDir:        baseDir,
+		MaxHeight:      *maxHeight,
 	})
 	if err != nil {
 		fatal(err)

--- a/md2png.go
+++ b/md2png.go
@@ -164,6 +164,7 @@ type canvas struct {
 	img     *image.RGBA
 	dc      *freetype.Context
 	w, h    int
+	maxH    int // Maximum permitted height
 	margin  int
 	cursorY int
 	lineGap int // pixels between text lines
@@ -172,9 +173,13 @@ type canvas struct {
 	ptSize  float64
 }
 
-func newCanvas(width int, margin int, th Theme, fonts Fonts, ptSize float64) *canvas {
-	// Start tall; we'll crop later
-	img := image.NewRGBA(image.Rect(0, 0, width, 4096*2))
+func newCanvas(width int, margin int, th Theme, fonts Fonts, ptSize float64, maxH int) *canvas {
+	startH := 8192
+	if startH > maxH {
+		startH = maxH
+	}
+	// Start tall; we'll grow later if needed
+	img := image.NewRGBA(image.Rect(0, 0, width, startH))
 	dc := freetype.NewContext()
 	dc.SetDPI(96)
 	dc.SetClip(img.Bounds())
@@ -191,6 +196,7 @@ func newCanvas(width int, margin int, th Theme, fonts Fonts, ptSize float64) *ca
 		dc:      dc,
 		w:       width,
 		h:       img.Bounds().Dy(),
+		maxH:    maxH,
 		margin:  margin,
 		cursorY: margin,
 		lineGap: 4,
@@ -198,6 +204,38 @@ func newCanvas(width int, margin int, th Theme, fonts Fonts, ptSize float64) *ca
 		fonts:   fonts,
 		ptSize:  ptSize,
 	}
+}
+
+func (c *canvas) ensureHeightAbs(targetY int) {
+	if targetY <= c.h {
+		return
+	}
+	if c.maxH > 0 && targetY > c.maxH {
+		panic(fmt.Errorf("md2png: maximum output height limit exceeded (%d > %d)", targetY, c.maxH))
+	}
+
+	newH := c.h * 2
+	if newH < targetY+4096 {
+		newH = targetY + 4096
+	}
+	if c.maxH > 0 && newH > c.maxH {
+		newH = c.maxH
+	}
+
+	newImg := image.NewRGBA(image.Rect(0, 0, c.w, newH))
+	draw.Draw(newImg, newImg.Bounds(), image.NewUniform(c.th.BG), image.Point{}, draw.Src)
+	draw.Draw(newImg, c.img.Bounds(), c.img, image.Point{}, draw.Src)
+
+	c.img = newImg
+	c.h = newH
+
+	c.dc = freetype.NewContext()
+	c.dc.SetDPI(96)
+	c.dc.SetClip(c.img.Bounds())
+	c.dc.SetDst(c.img)
+	c.dc.SetSrc(image.NewUniform(c.th.FG))
+	c.dc.SetFont(nil)
+	c.dc.SetFontSize(c.ptSize)
 }
 
 func (c *canvas) setFace(fnt *FontAndFace, color color.Color, size float64) {
@@ -257,10 +295,14 @@ func measureWidth(fnt *FontAndFace, size float64, s string) float64 {
 	return width
 }
 
-func (c *canvas) addVSpace(px int) { c.cursorY += px }
+func (c *canvas) addVSpace(px int) {
+	c.ensureHeightAbs(c.cursorY + px)
+	c.cursorY += px
+}
 
 func (c *canvas) drawHRule() {
 	y := c.cursorY + 4
+	c.ensureHeightAbs(y + 2)
 	rect := image.Rect(c.margin, y, c.w-c.margin, y+2)
 	draw.Draw(c.img, rect, image.NewUniform(c.th.HRule), image.Point{}, draw.Src)
 	c.cursorY = y + 10
@@ -268,6 +310,7 @@ func (c *canvas) drawHRule() {
 
 func (c *canvas) drawBlockquoteBar(topY, height int) {
 	x0 := c.margin
+	c.ensureHeightAbs(topY + height)
 	rect := image.Rect(x0, topY, x0+4, topY+height)
 	draw.Draw(c.img, rect, image.NewUniform(c.th.QuoteBar), image.Point{}, draw.Src)
 }
@@ -280,6 +323,9 @@ func (c *canvas) drawCodeBlock(text string, left, right int, size float64) {
 	lines := wrapLines(mono, size, text, float64(right-left-2*pad))
 	lineHeight := int(size * 1.4)
 	height := len(lines)*lineHeight + 2*pad + 6
+
+	c.ensureHeightAbs(top + height + 6)
+
 	// bg
 	rect := image.Rect(left, top, right, top+height)
 	draw.Draw(c.img, rect, image.NewUniform(c.th.CodeBG), image.Point{}, draw.Src)
@@ -734,6 +780,7 @@ func (r *renderer) drawListMarker(marker string, baseline int, markerLeft, marke
 	if font == nil {
 		return
 	}
+	r.c.ensureHeightAbs(baseline + int(r.baseSize))
 	r.c.setFace(font, r.c.th.FG, r.baseSize)
 	width := measureWidth(font, r.baseSize, marker)
 	x := markerRight - int(width)
@@ -779,6 +826,12 @@ func (c *canvas) drawTokens(tokens []textToken, left, right int) []lineMetric {
 			baselineSize = c.ptSize
 		}
 		baseline := c.cursorY + int(baselineSize)
+		lineHeight := int(baselineSize * 1.4)
+		if lineHeight <= 0 {
+			lineHeight = int(c.ptSize * 1.4)
+		}
+		c.ensureHeightAbs(baseline + lineHeight)
+
 		x := left
 		for _, w := range line {
 			if w.font == nil {
@@ -798,10 +851,7 @@ func (c *canvas) drawTokens(tokens []textToken, left, right int) []lineMetric {
 			}
 			x += width
 		}
-		lineHeight := int(baselineSize * 1.4)
-		if lineHeight <= 0 {
-			lineHeight = int(c.ptSize * 1.4)
-		}
+
 		metrics = append(metrics, lineMetric{baseline: baseline, height: lineHeight})
 		c.cursorY += lineHeight
 		line = line[:0]
@@ -829,6 +879,9 @@ func (c *canvas) drawTokens(tokens []textToken, left, right int) []lineMetric {
 			if tok.center && maxWidthInt > drawWidth {
 				x += (maxWidthInt - drawWidth) / 2
 			}
+
+			c.ensureHeightAbs(startY + drawHeight + int(c.ptSize*0.6))
+
 			rect := image.Rect(x, startY, x+drawWidth, startY+drawHeight)
 			draw.Draw(c.img, rect, img, bounds.Min, draw.Over)
 			baseline := startY + int(c.ptSize)
@@ -1108,11 +1161,13 @@ func (r *renderer) renderTable(tbl *extensionAST.Table, md []byte) {
 			maxCellHeight = int(r.baseSize * 1.1)
 		}
 		rowBottom := rowTop + maxCellHeight + 2*cellPadding
+		r.c.ensureHeightAbs(rowBottom + border)
 		draw.Draw(r.c.img, image.Rect(tableLeft, rowBottom, tableRight, rowBottom+border), borderColor, image.Point{}, draw.Src)
 		y = rowBottom + border
 	}
 
 	tableBottom := y - border
+	r.c.ensureHeightAbs(tableBottom + border)
 	for col := 0; col <= colCount; col++ {
 		x := tableLeft + col*(colWidth+border)
 		draw.Draw(r.c.img, image.Rect(x, tableTop, x+border, tableBottom+border), borderColor, image.Point{}, draw.Src)
@@ -1267,12 +1322,23 @@ type RenderOptions struct {
 	LinkFootnotes  *bool
 	ImageFootnotes *bool
 	BaseDir        string
+	MaxHeight      int // Maximum permitted output height to prevent out-of-memory on large documents
 }
 
 // Render converts the provided Markdown document into a raster image using the
 // supplied options. Zero values enable sensible defaults (1024px width,
 // 48px margin, 16pt base font, light theme, bundled fonts).
-func Render(data []byte, opts RenderOptions) (*image.RGBA, error) {
+func Render(data []byte, opts RenderOptions) (resImg *image.RGBA, resErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if err, ok := r.(error); ok && strings.HasPrefix(err.Error(), "md2png: maximum output height limit exceeded") {
+				resErr = err
+			} else {
+				panic(r)
+			}
+		}
+	}()
+
 	if opts.Width <= 0 {
 		opts.Width = 1024
 	}
@@ -1284,6 +1350,9 @@ func Render(data []byte, opts RenderOptions) (*image.RGBA, error) {
 	}
 	if (opts.Theme == Theme{}) {
 		opts.Theme = lightTheme
+	}
+	if opts.MaxHeight == 0 {
+		opts.MaxHeight = 32768
 	}
 
 	// Fill in missing fonts using the bundled defaults.
@@ -1327,7 +1396,7 @@ func Render(data []byte, opts RenderOptions) (*image.RGBA, error) {
 		}
 	}
 
-	c := newCanvas(opts.Width, opts.Margin, opts.Theme, opts.Fonts, opts.BaseFontSize)
+	c := newCanvas(opts.Width, opts.Margin, opts.Theme, opts.Fonts, opts.BaseFontSize, opts.MaxHeight)
 	r := &renderer{
 		c:              c,
 		baseSize:       opts.BaseFontSize,
@@ -1344,6 +1413,8 @@ func Render(data []byte, opts RenderOptions) (*image.RGBA, error) {
 	if used < opts.Margin+50 {
 		used = opts.Margin + 50
 	}
+
+	c.ensureHeightAbs(used)
 
 	img := image.NewRGBA(image.Rect(0, 0, opts.Width, used))
 	draw.Draw(img, img.Bounds(), c.img, image.Point{}, draw.Src)

--- a/md2png.go
+++ b/md2png.go
@@ -1066,11 +1066,11 @@ func (r *renderer) renderTable(tbl *extensionAST.Table, md []byte) {
 			// Let's create a pseudo-row just to pass to a logic, or adjust.
 			// The original code was:
 			/*
-			for child := n.FirstChild(); child != nil; child = child.NextSibling() {
-				if tr, ok := child.(*extensionAST.TableRow); ok {
-					rows = append(rows, r.collectTableRow(tr, md, true))
+				for child := n.FirstChild(); child != nil; child = child.NextSibling() {
+					if tr, ok := child.(*extensionAST.TableRow); ok {
+						rows = append(rows, r.collectTableRow(tr, md, true))
+					}
 				}
-			}
 			*/
 			// Since we know TableHeader directly contains TableCells, let's collect them!
 			var cells [][]textToken
@@ -1350,6 +1350,9 @@ func Render(data []byte, opts RenderOptions) (resImg *image.RGBA, resErr error) 
 	}
 	if (opts.Theme == Theme{}) {
 		opts.Theme = lightTheme
+	}
+	if opts.MaxHeight < 0 {
+		return nil, errors.New("md2png: MaxHeight cannot be negative")
 	}
 	if opts.MaxHeight == 0 {
 		opts.MaxHeight = 32768

--- a/md2png_test.go
+++ b/md2png_test.go
@@ -102,7 +102,7 @@ func TestRendererFootnoteCollection(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load fonts: %v", err)
 	}
-	c := newCanvas(640, 48, lightTheme, fonts, 16)
+	c := newCanvas(640, 48, lightTheme, fonts, 16, 32768)
 	r := &renderer{
 		c:              c,
 		baseSize:       16,
@@ -127,7 +127,7 @@ func TestRendererFootnoteToggles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load fonts: %v", err)
 	}
-	c := newCanvas(640, 48, lightTheme, fonts, 16)
+	c := newCanvas(640, 48, lightTheme, fonts, 16, 32768)
 	r := &renderer{
 		c:              c,
 		baseSize:       16,
@@ -251,5 +251,63 @@ func TestRenderEmbedsRemoteImage(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("expected rendered output to include remote image pixels")
+	}
+}
+
+func TestMaxHeightLimit(t *testing.T) {
+	markdown := "Test height limit\n\n"
+	for i := 0; i < 1000; i++ {
+		markdown += "Line " + fmt.Sprint(i) + "\n\n"
+	}
+
+	_, err := Render([]byte(markdown), RenderOptions{MaxHeight: 2000})
+	if err == nil {
+		t.Fatalf("expected error due to height limit exceeded, got nil")
+	}
+	if !strings.Contains(err.Error(), "maximum output height limit exceeded") {
+		t.Fatalf("expected height limit error message, got: %v", err)
+	}
+}
+
+func TestRenderBeyond8192px(t *testing.T) {
+	markdown := "# Tall Document\n\n"
+	for i := 0; i < 1000; i++ {
+		markdown += "Paragraph line " + fmt.Sprint(i) + "\n\n"
+	}
+
+	// Add an explicit colored marker at the bottom that we can test for.
+	markdown += "## The End\n\nThis is the bottom text with a [link](https://example.com/bottom) at the end."
+
+	img, err := Render([]byte(markdown), RenderOptions{MaxHeight: 60000})
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+	if img == nil {
+		t.Fatalf("expected image result")
+	}
+	if img.Bounds().Dy() < 10000 {
+		t.Fatalf("expected image height to be well over 8192px, got %d", img.Bounds().Dy())
+	}
+
+	// Ensure that meaningful pixels exist near the bottom of the image
+	// by searching for the link color which we added at the end of the markdown.
+	bounds := img.Bounds()
+	foundLinkPixel := false
+	// Start searching from the bottom upwards (last 200 pixels should cover it)
+	startY := bounds.Max.Y - 200
+	if startY < bounds.Min.Y {
+		startY = bounds.Min.Y
+	}
+	for y := startY; y < bounds.Max.Y && !foundLinkPixel; y++ {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			r, g, b, a := img.At(x, y).RGBA()
+			if uint8(r>>8) == linkColor.R && uint8(g>>8) == linkColor.G && uint8(b>>8) == linkColor.B && uint8(a>>8) == linkColor.A {
+				foundLinkPixel = true
+				break
+			}
+		}
+	}
+	if !foundLinkPixel {
+		t.Fatalf("expected meaningful rendered pixels (link) near the bottom of a >8192px image")
 	}
 }

--- a/md2png_test.go
+++ b/md2png_test.go
@@ -279,11 +279,55 @@ func TestNegativeMaxHeight(t *testing.T) {
 	}
 }
 
+func TestZeroMaxHeightDefaults(t *testing.T) {
+	// 0 defaults to 32768, so parsing 2000 lines (which takes ~70000 pixels) should fail
+	markdown := "Test height limit\n\n"
+	for i := 0; i < 2000; i++ {
+		markdown += "Line " + fmt.Sprint(i) + "\n\n"
+	}
+
+	_, err := Render([]byte(markdown), RenderOptions{MaxHeight: 0})
+	if err == nil {
+		t.Fatalf("expected error due to height limit exceeded on default 0 (32768), got nil")
+	}
+	if !strings.Contains(err.Error(), "maximum output height limit exceeded") {
+		t.Fatalf("expected height limit error message, got: %v", err)
+	}
+}
+
 func TestRenderBeyond8192pxElements(t *testing.T) {
+	// We want to force the cursor specifically near the 8192px boundary, then
+	// have the target block start just *above* 8192 and finish *below* 8192.
+	// Since font rendering logic can be complex to guess exact pixel heights,
+	// we use exact canvas measurement inside the test loops.
+
+	getCursorHeight := func(md []byte) int {
+		// Do a quick dry-run render to see how tall it gets.
+		img, _ := Render(md, RenderOptions{MaxHeight: 60000, Width: 400})
+		if img == nil {
+			return 0
+		}
+		return img.Bounds().Dy()
+	}
+
+	buildSpacersTo := func(target int) string {
+		markdown := "# Boundary\n\n"
+		for {
+			nextMarkdown := markdown + "Spacer to push content down\n\n"
+			height := getCursorHeight([]byte(nextMarkdown))
+			if height > target {
+				break
+			}
+			markdown = nextMarkdown
+		}
+		return markdown
+	}
+
 	// 1. Image
 	t.Run("Image", func(t *testing.T) {
 		tmpDir := t.TempDir()
-		block := image.NewRGBA(image.Rect(0, 0, 40, 20))
+		// Make a very tall image so it easily spans across the boundary.
+		block := image.NewRGBA(image.Rect(0, 0, 40, 600))
 		want := color.RGBA{R: 0xCC, G: 0x22, B: 0x22, A: 0xFF}
 		draw.Draw(block, block.Bounds(), image.NewUniform(want), image.Point{}, draw.Src)
 		imgPath := filepath.Join(tmpDir, "block.png")
@@ -297,10 +341,8 @@ func TestRenderBeyond8192pxElements(t *testing.T) {
 		}
 		_ = file.Close()
 
-		markdown := "# Image Boundary\n\n"
-		for i := 0; i < 500; i++ {
-			markdown += "Spacer to push content down\n\n"
-		}
+		// Get exactly under 8192
+		markdown := buildSpacersTo(8150)
 		markdown += fmt.Sprintf("![local image](%s)\n\n", filepath.Base(imgPath))
 
 		img, err := Render([]byte(markdown), RenderOptions{BaseDir: tmpDir, MaxHeight: 60000, Width: 400})
@@ -311,28 +353,41 @@ func TestRenderBeyond8192pxElements(t *testing.T) {
 			t.Fatalf("expected image height > 8192px, got %d", img.Bounds().Dy())
 		}
 
-		found := false
+		// Ensure we see image pixels *above* 8192 (i.e. the image started before the growth bound)
+		foundAbove := false
 		bounds := img.Bounds()
-		for y := 8192; y < bounds.Max.Y && !found; y++ {
+		for y := bounds.Min.Y; y < 8192 && !foundAbove; y++ {
 			for x := bounds.Min.X; x < bounds.Max.X; x++ {
 				r, g, b, a := img.At(x, y).RGBA()
 				if uint8(r>>8) == want.R && uint8(g>>8) == want.G && uint8(b>>8) == want.B && uint8(a>>8) == want.A {
-					found = true
+					foundAbove = true
 					break
 				}
 			}
 		}
-		if !found {
-			t.Fatalf("expected embedded image pixels below 8192px")
+		if !foundAbove {
+			t.Fatalf("expected embedded image pixels ABOVE 8192px (image should span across boundary)")
+		}
+
+		// Ensure we see image pixels *below* 8192 (i.e. the image successfully forced a growth)
+		foundBelow := false
+		for y := 8192; y < bounds.Max.Y && !foundBelow; y++ {
+			for x := bounds.Min.X; x < bounds.Max.X; x++ {
+				r, g, b, a := img.At(x, y).RGBA()
+				if uint8(r>>8) == want.R && uint8(g>>8) == want.G && uint8(b>>8) == want.B && uint8(a>>8) == want.A {
+					foundBelow = true
+					break
+				}
+			}
+		}
+		if !foundBelow {
+			t.Fatalf("expected embedded image pixels BELOW 8192px")
 		}
 	})
 
 	// 2. Code Block
 	t.Run("CodeBlock", func(t *testing.T) {
-		markdown := "# Code Block Boundary\n\n"
-		for i := 0; i < 500; i++ {
-			markdown += "Spacer to push content down\n\n"
-		}
+		markdown := buildSpacersTo(8150)
 		markdown += "```\n"
 		for i := 0; i < 50; i++ {
 			markdown += "func bottomCodeBlockLine() {}\n"
@@ -347,30 +402,43 @@ func TestRenderBeyond8192pxElements(t *testing.T) {
 			t.Fatalf("expected image height > 8192px, got %d", img.Bounds().Dy())
 		}
 
-		// Check for code block background color below 8192
-		found := false
 		bounds := img.Bounds()
 		cR, cG, cB, cA := lightTheme.CodeBG.RGBA()
-		for y := 8192; y < bounds.Max.Y && !found; y++ {
+
+		// Above boundary
+		foundAbove := false
+		for y := bounds.Min.Y; y < 8192 && !foundAbove; y++ {
 			for x := bounds.Min.X; x < bounds.Max.X; x++ {
 				r, g, b, a := img.At(x, y).RGBA()
 				if r == cR && g == cG && b == cB && a == cA {
-					found = true
+					foundAbove = true
 					break
 				}
 			}
 		}
-		if !found {
-			t.Fatalf("expected code block background pixels below 8192px")
+		if !foundAbove {
+			t.Fatalf("expected code block background pixels ABOVE 8192px (codeblock should span across boundary)")
+		}
+
+		// Below boundary
+		foundBelow := false
+		for y := 8192; y < bounds.Max.Y && !foundBelow; y++ {
+			for x := bounds.Min.X; x < bounds.Max.X; x++ {
+				r, g, b, a := img.At(x, y).RGBA()
+				if r == cR && g == cG && b == cB && a == cA {
+					foundBelow = true
+					break
+				}
+			}
+		}
+		if !foundBelow {
+			t.Fatalf("expected code block background pixels BELOW 8192px")
 		}
 	})
 
 	// 3. Table
 	t.Run("Table", func(t *testing.T) {
-		markdown := "# Table Boundary\n\n"
-		for i := 0; i < 500; i++ {
-			markdown += "Spacer to push content down\n\n"
-		}
+		markdown := buildSpacersTo(8150)
 		markdown += "| Col 1 | Col 2 |\n|---|---|\n"
 		for i := 0; i < 50; i++ {
 			markdown += fmt.Sprintf("| Val %d | [link](https://example.com) |\n", i)
@@ -384,20 +452,36 @@ func TestRenderBeyond8192pxElements(t *testing.T) {
 			t.Fatalf("expected image height > 8192px, got %d", img.Bounds().Dy())
 		}
 
-		// Check for link color (inside the table cells) below 8192
-		found := false
 		bounds := img.Bounds()
-		for y := 8192; y < bounds.Max.Y && !found; y++ {
+
+		// Above boundary
+		foundAbove := false
+		for y := bounds.Min.Y; y < 8192 && !foundAbove; y++ {
 			for x := bounds.Min.X; x < bounds.Max.X; x++ {
 				r, g, b, a := img.At(x, y).RGBA()
 				if uint8(r>>8) == linkColor.R && uint8(g>>8) == linkColor.G && uint8(b>>8) == linkColor.B && uint8(a>>8) == linkColor.A {
-					found = true
+					foundAbove = true
 					break
 				}
 			}
 		}
-		if !found {
-			t.Fatalf("expected table cell content (link pixels) below 8192px")
+		if !foundAbove {
+			t.Fatalf("expected table cell content (link pixels) ABOVE 8192px (table should span across boundary)")
+		}
+
+		// Below boundary
+		foundBelow := false
+		for y := 8192; y < bounds.Max.Y && !foundBelow; y++ {
+			for x := bounds.Min.X; x < bounds.Max.X; x++ {
+				r, g, b, a := img.At(x, y).RGBA()
+				if uint8(r>>8) == linkColor.R && uint8(g>>8) == linkColor.G && uint8(b>>8) == linkColor.B && uint8(a>>8) == linkColor.A {
+					foundBelow = true
+					break
+				}
+			}
+		}
+		if !foundBelow {
+			t.Fatalf("expected table cell content (link pixels) BELOW 8192px")
 		}
 	})
 }

--- a/md2png_test.go
+++ b/md2png_test.go
@@ -269,6 +269,139 @@ func TestMaxHeightLimit(t *testing.T) {
 	}
 }
 
+func TestNegativeMaxHeight(t *testing.T) {
+	_, err := Render([]byte("# Hello"), RenderOptions{MaxHeight: -1})
+	if err == nil {
+		t.Fatalf("expected error for negative MaxHeight, got nil")
+	}
+	if !strings.Contains(err.Error(), "MaxHeight cannot be negative") {
+		t.Fatalf("expected specific negative MaxHeight error message, got: %v", err)
+	}
+}
+
+func TestRenderBeyond8192pxElements(t *testing.T) {
+	// 1. Image
+	t.Run("Image", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		block := image.NewRGBA(image.Rect(0, 0, 40, 20))
+		want := color.RGBA{R: 0xCC, G: 0x22, B: 0x22, A: 0xFF}
+		draw.Draw(block, block.Bounds(), image.NewUniform(want), image.Point{}, draw.Src)
+		imgPath := filepath.Join(tmpDir, "block.png")
+		file, err := os.Create(imgPath)
+		if err != nil {
+			t.Fatalf("create temp image: %v", err)
+		}
+		if err := png.Encode(file, block); err != nil {
+			_ = file.Close()
+			t.Fatalf("encode temp image: %v", err)
+		}
+		_ = file.Close()
+
+		markdown := "# Image Boundary\n\n"
+		for i := 0; i < 500; i++ {
+			markdown += "Spacer to push content down\n\n"
+		}
+		markdown += fmt.Sprintf("![local image](%s)\n\n", filepath.Base(imgPath))
+
+		img, err := Render([]byte(markdown), RenderOptions{BaseDir: tmpDir, MaxHeight: 60000, Width: 400})
+		if err != nil {
+			t.Fatalf("render failed: %v", err)
+		}
+		if img.Bounds().Dy() <= 8192 {
+			t.Fatalf("expected image height > 8192px, got %d", img.Bounds().Dy())
+		}
+
+		found := false
+		bounds := img.Bounds()
+		for y := 8192; y < bounds.Max.Y && !found; y++ {
+			for x := bounds.Min.X; x < bounds.Max.X; x++ {
+				r, g, b, a := img.At(x, y).RGBA()
+				if uint8(r>>8) == want.R && uint8(g>>8) == want.G && uint8(b>>8) == want.B && uint8(a>>8) == want.A {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("expected embedded image pixels below 8192px")
+		}
+	})
+
+	// 2. Code Block
+	t.Run("CodeBlock", func(t *testing.T) {
+		markdown := "# Code Block Boundary\n\n"
+		for i := 0; i < 500; i++ {
+			markdown += "Spacer to push content down\n\n"
+		}
+		markdown += "```\n"
+		for i := 0; i < 50; i++ {
+			markdown += "func bottomCodeBlockLine() {}\n"
+		}
+		markdown += "```\n"
+
+		img, err := Render([]byte(markdown), RenderOptions{MaxHeight: 60000, Width: 400})
+		if err != nil {
+			t.Fatalf("render failed: %v", err)
+		}
+		if img.Bounds().Dy() <= 8192 {
+			t.Fatalf("expected image height > 8192px, got %d", img.Bounds().Dy())
+		}
+
+		// Check for code block background color below 8192
+		found := false
+		bounds := img.Bounds()
+		cR, cG, cB, cA := lightTheme.CodeBG.RGBA()
+		for y := 8192; y < bounds.Max.Y && !found; y++ {
+			for x := bounds.Min.X; x < bounds.Max.X; x++ {
+				r, g, b, a := img.At(x, y).RGBA()
+				if r == cR && g == cG && b == cB && a == cA {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("expected code block background pixels below 8192px")
+		}
+	})
+
+	// 3. Table
+	t.Run("Table", func(t *testing.T) {
+		markdown := "# Table Boundary\n\n"
+		for i := 0; i < 500; i++ {
+			markdown += "Spacer to push content down\n\n"
+		}
+		markdown += "| Col 1 | Col 2 |\n|---|---|\n"
+		for i := 0; i < 50; i++ {
+			markdown += fmt.Sprintf("| Val %d | [link](https://example.com) |\n", i)
+		}
+
+		img, err := Render([]byte(markdown), RenderOptions{MaxHeight: 60000, Width: 400})
+		if err != nil {
+			t.Fatalf("render failed: %v", err)
+		}
+		if img.Bounds().Dy() <= 8192 {
+			t.Fatalf("expected image height > 8192px, got %d", img.Bounds().Dy())
+		}
+
+		// Check for link color (inside the table cells) below 8192
+		found := false
+		bounds := img.Bounds()
+		for y := 8192; y < bounds.Max.Y && !found; y++ {
+			for x := bounds.Min.X; x < bounds.Max.X; x++ {
+				r, g, b, a := img.At(x, y).RGBA()
+				if uint8(r>>8) == linkColor.R && uint8(g>>8) == linkColor.G && uint8(b>>8) == linkColor.B && uint8(a>>8) == linkColor.A {
+					found = true
+					break
+				}
+			}
+		}
+		if !found {
+			t.Fatalf("expected table cell content (link pixels) below 8192px")
+		}
+	})
+}
+
 func TestRenderBeyond8192px(t *testing.T) {
 	markdown := "# Tall Document\n\n"
 	for i := 0; i < 1000; i++ {


### PR DESCRIPTION
Fixes #60

**Context**
Previously, `md2png` allocated a fixed-size `8192px` (4096*2) backing canvas when rendering Markdown images. If the rendered content exceeded this arbitrary height, any drawing operations beyond 8192px were silently clipped, leading to truncated outputs for long documents. 

**Allocation/Growth Strategy**
To fix this, the fixed-height limitation was removed in favor of a dynamic canvas growth strategy:
- The initial canvas allocation still respects a reasonable baseline size or the max bound.
- During rendering, all layout functions (`addVSpace`, `drawTokens`, `drawCodeBlock`, `renderTable`, etc.) check if the incoming drawing operations will exceed the current canvas height via `ensureHeightAbs(targetY)`.
- If `targetY` exceeds the current capacity, a new, larger `*image.RGBA` is allocated (doubling the current size or adding 4096px, whichever safely bounds `targetY`).
- The existing pixel content is copied to the new canvas via `draw.Draw`, and the `freetype.Context` is safely re-initialized and re-clipped to match the newly expanded bounds without losing rendering states.

**Resource Limits**
To prevent pathological or infinitely-looping inputs from causing unbounded out-of-memory allocations, an explicit `MaxHeight` resource limit was added:
- `RenderOptions` now accepts a `MaxHeight` setting (defaulting to `32768px` if not specified).
- `ensureHeightAbs` enforces this policy. If the requested `targetY` is strictly greater than `MaxHeight`, it triggers a dedicated panic.
- The top-level `Render` entrypoint uses a deferred `recover()` block that catches this specific panic to return a clean, documented `fmt.Errorf("maximum output height limit exceeded...")` instead of crashing the process or silently clipping. Backward compatibility of the `Render` signature and behavior (for typical-sized files) is entirely preserved.

**Regression Testing**
Comprehensive regression testing was implemented:
- `TestMaxHeightLimit`: Validates that rendering an excessively large document returns the expected maximum height error limit.
- `TestRenderBeyond8192px`: Synthesizes a massive Markdown document designed to exceed the old 8192px truncation boundary. The test ensures that the resulting image's height explicitly breaches 10000px, and strictly validates the unclipped state by searching for a uniquely colored hyperlink injected exactly at the document's tail-end. 

Verified manually by regenerating long `README.md` test outputs locally (light and dark mode) to confirm seamless canvas boundary crossing.

---
*PR created automatically by Jules for task [11446232462108581584](https://jules.google.com/task/11446232462108581584) started by @arran4*