### PR TITLE
feat: explicit image security policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,45 @@ func main() {
 
 `RenderOptions` exposes the same knobs as the CLI. Set custom dimensions, limits (`MaxHeight`), swap themes, toggle link or image footnotes, or pass a font set created with `md2png.LoadFonts`.
 
+### Security and Image Loading Policy
+
+Rendering Markdown documents containing image tags (`![alt](url)`) can initiate filesystem access (for local paths or `file://` URLs) and network requests (for `http://` or `https://` URLs).
+
+#### Trusted CLI vs. Untrusted Input
+
+- **Default / CLI behavior (`DefaultCLIImagePolicy()`)**:
+  When using the CLI tools (`md2png`, `md2view`) or leaving `RenderOptions.ImagePolicy` as `nil`, `md2png` uses `DefaultCLIImagePolicy()`. This mode assumes trusted input and permits loading local images from the filesystem and remote images over HTTP/HTTPS, bounded by sensible safety limits (50 MB response limit, 8192×8192 px max dimensions, 1000 cache items). Missing images in trusted mode non-fatally fall back to alt text.
+
+- **Untrusted Markdown (`StrictImagePolicy()`)**:
+  When rendering Markdown from untrusted sources, configure a strict policy to prevent unauthorized filesystem disclosure and SSRF attacks:
+
+  ```go
+  policy := md2png.StrictImagePolicy()
+  opts := md2png.RenderOptions{
+      ImagePolicy: &policy,
+  }
+  img, err := md2png.Render(untrustedData, opts)
+  ```
+
+  `StrictImagePolicy()` disables local file access (`AllowLocal: false`), sandboxes local paths to `RenderOptions.BaseDir` (`SandboxLocal: true`), disables network requests (`AllowRemote: false`), limits images to 4096×4096 px and 5 MB, and bounds cache capacity to 100 items. Any policy denial, sandbox violation, or resource limit halts rendering immediately and returns typed sentinel errors (`ErrPolicyDenied`, `ErrSandboxViolation`, `ErrResourceLimit`).
+
+#### Policy Controls
+
+You can customize `md2png.ImagePolicy` with fine-grained controls:
+
+| Control | Description |
+|---|---|
+| `AllowLocal` | Enables/disables reading local image files (`file://` or relative paths). |
+| `SandboxLocal` | When `true`, restricts local access strictly to `RenderOptions.BaseDir`, rejecting `..` traversal escapes, absolute filesystem paths, symlink escapes, and `file://` bypasses. |
+| `AllowRemote` | Enables/disables fetching remote images over HTTP and HTTPS. |
+| `MaxRemoteBytes` | Maximum permitted response size in bytes for remote images (0 for unlimited). Oversized responses fail deterministically before loading into memory. |
+| `MaxImageWidth` | Maximum image width in pixels. Evaluated via `image.DecodeConfig` before full decompression. |
+| `MaxImageHeight` | Maximum image height in pixels. Evaluated before full decompression. |
+| `MaxImagePixels` | Maximum total pixels (width × height) to protect against decompression bombs. |
+| `MaxCacheItems` | Maximum number of decoded images retained in the renderer cache (evicted using FIFO). |
+| `Context` | A `context.Context` for request cancellation and timeouts (`errors.Is(err, context.Canceled)` or `errors.Is(err, context.DeadlineExceeded)`). |
+| `HTTPClient` | A caller-supplied `*http.Client` to control custom transports, proxy resolvers, or redirect policies without mutation. Redirects to non-HTTP(S) schemes are rejected. |
+
 ---
 
 ## Output

--- a/internal/cli/cli_options.go
+++ b/internal/cli/cli_options.go
@@ -47,10 +47,12 @@ func ConvertCommandArgsToRenderOptions(
 		return md2png.RenderOptions{}, err
 	}
 
+	policy := md2png.DefaultCLIImagePolicy()
 	opts := md2png.RenderOptions{
-		Theme:   th,
-		Fonts:   fonts,
-		BaseDir: baseDir,
+		Theme:       th,
+		Fonts:       fonts,
+		BaseDir:     baseDir,
+		ImagePolicy: &policy,
 	}
 
 	if width != nil {

--- a/md2png.go
+++ b/md2png.go
@@ -2,6 +2,7 @@ package md2png
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"image"
@@ -46,6 +47,8 @@ var (
 	ErrInvalidMaxHeight = errors.New("md2png: invalid max height")
 	ErrNoDrawableWidth  = errors.New("md2png: margin leaves no useful drawable width")
 	ErrResourceLimit    = errors.New("md2png: dimension exceeds resource limit")
+	ErrPolicyDenied     = errors.New("md2png: image loading denied by policy")
+	ErrSandboxViolation = errors.New("md2png: path violates sandbox restrictions")
 )
 
 const (
@@ -509,6 +512,7 @@ type renderer struct {
 	imageCache     map[string]image.Image
 	imageResolvers map[string]imageResolver
 	httpClient     *http.Client
+	imagePolicy    ImagePolicy
 }
 
 type imageResolver func(dest string) (cacheKey string, loader func() (image.Image, error), err error)
@@ -567,7 +571,18 @@ func (r *renderer) appendFootnoteMarker(out *[]textToken, size float64, index in
 
 func (r *renderer) ensureImageResolvers() {
 	if r.httpClient == nil {
-		r.httpClient = &http.Client{Timeout: 15 * time.Second}
+		r.httpClient = &http.Client{
+			Timeout: 15 * time.Second,
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+					return fmt.Errorf("%w: redirect to non-http(s) scheme", ErrPolicyDenied)
+				}
+				if len(via) >= 10 {
+					return errors.New("stopped after 10 redirects")
+				}
+				return nil
+			},
+		}
 	}
 	if r.imageResolvers != nil {
 		return
@@ -731,6 +746,13 @@ func (r *renderer) collectInlineTokens(node ast.Node, md []byte, font *FontAndFa
 			if img, err := r.loadImage(dest); err == nil {
 				*out = append(*out, textToken{image: img, center: true})
 			} else {
+				if errors.Is(err, context.DeadlineExceeded) ||
+					errors.Is(err, context.Canceled) ||
+					errors.Is(err, ErrPolicyDenied) ||
+					errors.Is(err, ErrResourceLimit) ||
+					errors.Is(err, ErrSandboxViolation) {
+					panic(err) // let Render recover this and return correctly
+				}
 				fallback := alt
 				fallbackColor := r.c.th.FG
 				if fallback == "" {
@@ -1357,20 +1379,71 @@ func LoadFonts(cfg FontConfig) (Fonts, error) {
 	return loadFonts(cfg)
 }
 
+// ImagePolicy defines rules for fetching and decoding images when rendering Markdown.
+type ImagePolicy struct {
+	// Local images
+	AllowLocal   bool
+	SandboxLocal bool // If true, restricts to BaseDir, rejects absolute/..
+
+	// Remote images
+	AllowRemote    bool
+	MaxRemoteBytes int64 // 0 means no limit
+
+	// Request handling
+	HTTPClient *http.Client
+	Context    context.Context
+
+	// Dimension limits
+	MaxImageWidth  int
+	MaxImageHeight int
+	MaxImagePixels int
+
+	MaxCacheItems int
+}
+
+// StrictImagePolicy returns a conservative ImagePolicy suitable for rendering untrusted Markdown.
+func StrictImagePolicy() ImagePolicy {
+	return ImagePolicy{
+		AllowLocal:     false,
+		SandboxLocal:   true,
+		AllowRemote:    false,
+		MaxRemoteBytes: 5 * 1024 * 1024,
+		MaxImageWidth:  4096,
+		MaxImageHeight: 4096,
+		MaxImagePixels: 4096 * 4096,
+		MaxCacheItems:  100,
+	}
+}
+
+// DefaultCLIImagePolicy returns a policy intended for normal trusted CLI usage.
+func DefaultCLIImagePolicy() ImagePolicy {
+	return ImagePolicy{
+		AllowLocal:     true,
+		SandboxLocal:   false,
+		AllowRemote:    true,
+		MaxRemoteBytes: 50 * 1024 * 1024,
+		MaxImageWidth:  8192,
+		MaxImageHeight: 8192,
+		MaxImagePixels: 8192 * 8192,
+		MaxCacheItems:  1000,
+	}
+}
+
 // RenderOptions configures the Markdown to image rendering process.
 // Zero values (or empty structs) will automatically populate with sensible defaults,
 // including a 1024px width, 48px margin, 16pt font, and a 32768px height limit.
 type RenderOptions struct {
-	Width          int     // Overall image width in pixels. Default is 1024, max is 32768.
-	Margin         int     // Border margin in pixels. Default is 48.
-	ZeroMargin     bool    // If true, intentionally use a 0 margin instead of the default.
-	BaseFontSize   float64 // Base font size in points. Default is 16, max is 1024.
-	Theme          Theme   // Color theme. Defaults to light theme.
-	Fonts          Fonts   // Font configuration. Defaults to bundled Go fonts.
-	LinkFootnotes  *bool   // Add footnotes for links. Defaults to true.
-	ImageFootnotes *bool   // Add footnotes for images. Defaults to false.
-	BaseDir        string  // Base directory for resolving local image paths.
-	MaxHeight      int     // Maximum permitted output height (default 32768) to prevent OOM.
+	Width          int          // Overall image width in pixels. Default is 1024, max is 32768.
+	Margin         int          // Border margin in pixels. Default is 48.
+	ZeroMargin     bool         // If true, intentionally use a 0 margin instead of the default.
+	BaseFontSize   float64      // Base font size in points. Default is 16, max is 1024.
+	Theme          Theme        // Color theme. Defaults to light theme.
+	Fonts          Fonts        // Font configuration. Defaults to bundled Go fonts.
+	LinkFootnotes  *bool        // Add footnotes for links. Defaults to true.
+	ImageFootnotes *bool        // Add footnotes for images. Defaults to false.
+	BaseDir        string       // Base directory for resolving local image paths.
+	MaxHeight      int          // Maximum permitted output height (default 32768) to prevent OOM.
+	ImagePolicy    *ImagePolicy // Policy for loading images. If nil, DefaultCLIImagePolicy is used.
 }
 
 // Render converts the provided Markdown document into a raster image using the
@@ -1380,12 +1453,19 @@ type RenderOptions struct {
 // or result in no useful drawable area (width <= 2*margin) will return sentinel errors.
 func Render(data []byte, opts RenderOptions) (resImg *image.RGBA, resErr error) {
 	defer func() {
-		if r := recover(); r != nil {
-			if err, ok := r.(error); ok && strings.HasPrefix(err.Error(), "md2png: maximum output height limit exceeded") {
-				resErr = err
-			} else {
-				panic(r)
+		if rv := recover(); rv != nil {
+			if err, ok := rv.(error); ok {
+				if strings.HasPrefix(err.Error(), "md2png: maximum output height limit exceeded") ||
+					errors.Is(err, context.DeadlineExceeded) ||
+					errors.Is(err, context.Canceled) ||
+					errors.Is(err, ErrPolicyDenied) ||
+					errors.Is(err, ErrResourceLimit) ||
+					errors.Is(err, ErrSandboxViolation) {
+					resErr = err
+					return
+				}
 			}
+			panic(rv)
 		}
 	}()
 
@@ -1475,12 +1555,18 @@ func Render(data []byte, opts RenderOptions) (resImg *image.RGBA, resErr error) 
 	}
 
 	c := newCanvas(opts.Width, opts.Margin, opts.Theme, opts.Fonts, opts.BaseFontSize, opts.MaxHeight)
+	policy := DefaultCLIImagePolicy()
+	if opts.ImagePolicy != nil {
+		policy = *opts.ImagePolicy
+	}
+
 	r := &renderer{
 		c:              c,
 		baseSize:       opts.BaseFontSize,
 		linkFootnotes:  linkFootnotes,
 		imageFootnotes: imageFootnotes,
 		baseDir:        baseDir,
+		imagePolicy:    policy,
 	}
 	r.ensureImageResolvers()
 	if err := r.render(data); err != nil {

--- a/md2png.go
+++ b/md2png.go
@@ -2,14 +2,20 @@ package md2png
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"image"
 	"image/color"
 	"image/draw"
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+	"io"
 	"math"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -510,6 +516,7 @@ type renderer struct {
 	footnotes      []string
 	baseDir        string
 	imageCache     map[string]image.Image
+	cacheKeys      []string
 	imageResolvers map[string]imageResolver
 	httpClient     *http.Client
 	imagePolicy    ImagePolicy
@@ -570,19 +577,59 @@ func (r *renderer) appendFootnoteMarker(out *[]textToken, size float64, index in
 	})
 }
 
+func (r *renderer) checkDimensions(width, height int) error {
+	if r.imagePolicy.MaxImageWidth > 0 && width > r.imagePolicy.MaxImageWidth {
+		return fmt.Errorf("%w: image width %d exceeds maximum allowed width %d", ErrResourceLimit, width, r.imagePolicy.MaxImageWidth)
+	}
+	if r.imagePolicy.MaxImageHeight > 0 && height > r.imagePolicy.MaxImageHeight {
+		return fmt.Errorf("%w: image height %d exceeds maximum allowed height %d", ErrResourceLimit, height, r.imagePolicy.MaxImageHeight)
+	}
+	if r.imagePolicy.MaxImagePixels > 0 {
+		if width > 0 && height > 0 {
+			maxPixels := int64(r.imagePolicy.MaxImagePixels)
+			w := int64(width)
+			h := int64(height)
+			if w > maxPixels/h || (w*h) > maxPixels {
+				return fmt.Errorf("%w: image pixels (%dx%d) exceeds maximum allowed pixels %d", ErrResourceLimit, width, height, r.imagePolicy.MaxImagePixels)
+			}
+		}
+	}
+	return nil
+}
+
 func (r *renderer) ensureImageResolvers() {
 	if r.httpClient == nil {
-		r.httpClient = &http.Client{
-			Timeout: 15 * time.Second,
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+		if r.imagePolicy.HTTPClient != nil {
+			clientCopy := *r.imagePolicy.HTTPClient
+			origCheckRedirect := clientCopy.CheckRedirect
+			clientCopy.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 				if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
-					return fmt.Errorf("%w: redirect to non-http(s) scheme", ErrPolicyDenied)
+					return fmt.Errorf("%w: disallowed redirect scheme %q", ErrPolicyDenied, req.URL.Scheme)
+				}
+				if origCheckRedirect != nil {
+					if err := origCheckRedirect(req, via); err != nil {
+						return fmt.Errorf("%w: redirect rejected: %w", ErrPolicyDenied, err)
+					}
 				}
 				if len(via) >= 10 {
 					return errors.New("stopped after 10 redirects")
 				}
 				return nil
-			},
+			}
+			r.httpClient = &clientCopy
+		} else {
+			r.httpClient = &http.Client{
+				Timeout: 15 * time.Second,
+				CheckRedirect: func(req *http.Request, via []*http.Request) error {
+					if req.URL.Scheme != "http" && req.URL.Scheme != "https" {
+						return fmt.Errorf("%w: disallowed redirect scheme %q", ErrPolicyDenied, req.URL.Scheme)
+					}
+					if len(via) >= 10 {
+						return errors.New("stopped after 10 redirects")
+					}
+					return nil
+				},
+			}
 		}
 	}
 	if r.imageResolvers != nil {
@@ -603,13 +650,35 @@ func (r *renderer) loadImage(dest string) (image.Image, error) {
 	r.ensureImageResolvers()
 	dest = strings.TrimSpace(dest)
 	scheme := ""
-	if idx := strings.Index(dest, "://"); idx != -1 {
-		scheme = strings.ToLower(dest[:idx])
+	if idx := strings.Index(dest, ":"); idx != -1 {
+		candidate := strings.ToLower(dest[:idx])
+		if len(candidate) == 1 && unicode.IsLetter(rune(candidate[0])) {
+			// Windows drive letter like C:\ or C:/
+			scheme = ""
+		} else {
+			valid := true
+			for i, ch := range candidate {
+				if i == 0 {
+					if !unicode.IsLetter(ch) {
+						valid = false
+						break
+					}
+				} else {
+					if !unicode.IsLetter(ch) && !unicode.IsDigit(ch) && ch != '+' && ch != '-' && ch != '.' {
+						valid = false
+						break
+					}
+				}
+			}
+			if valid {
+				scheme = candidate
+			}
+		}
 	}
 	resolver, ok := r.imageResolvers[scheme]
 	if !ok {
 		if scheme != "" {
-			return nil, fmt.Errorf("md2png: unsupported image scheme: %s", scheme)
+			return nil, fmt.Errorf("%w: unsupported image scheme: %s", ErrPolicyDenied, scheme)
 		}
 		return nil, fmt.Errorf("md2png: unsupported image destination: %s", dest)
 	}
@@ -632,34 +701,179 @@ func (r *renderer) loadImage(dest string) (image.Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	if r.imageCache == nil {
-		r.imageCache = make(map[string]image.Image)
+
+	maxItems := r.imagePolicy.MaxCacheItems
+	if maxItems > 0 {
+		if r.imageCache == nil {
+			r.imageCache = make(map[string]image.Image)
+		}
+		if _, ok := r.imageCache[cacheKey]; !ok {
+			for len(r.imageCache) >= maxItems && len(r.cacheKeys) > 0 {
+				oldest := r.cacheKeys[0]
+				r.cacheKeys = r.cacheKeys[1:]
+				delete(r.imageCache, oldest)
+			}
+			r.imageCache[cacheKey] = img
+			r.cacheKeys = append(r.cacheKeys, cacheKey)
+		} else {
+			r.imageCache[cacheKey] = img
+		}
 	}
-	r.imageCache[cacheKey] = img
 	return img, nil
 }
 
 func (r *renderer) resolveLocalImage(dest string) (string, func() (image.Image, error), error) {
+	if !r.imagePolicy.AllowLocal {
+		return "", nil, fmt.Errorf("%w: local image loading is disabled", ErrPolicyDenied)
+	}
+
 	path := strings.TrimSpace(dest)
-	path = strings.TrimPrefix(path, "file://")
-	if !filepath.IsAbs(path) {
-		base := strings.TrimSpace(r.baseDir)
-		if base != "" {
-			path = filepath.Join(base, path)
+	isFileURL := false
+	if strings.HasPrefix(strings.ToLower(path), "file:") {
+		isFileURL = true
+		path = path[5:]
+		if strings.HasPrefix(path, "//localhost/") {
+			path = path[11:]
+		} else if strings.HasPrefix(path, "//localhost") {
+			path = path[11:]
+		} else if strings.HasPrefix(path, "//") {
+			path = path[2:]
 		}
 	}
-	cleaned := filepath.Clean(path)
+
+	if unescaped, err := url.PathUnescape(path); err == nil {
+		path = unescaped
+	}
+
+	baseDir := strings.TrimSpace(r.baseDir)
+	if baseDir == "" {
+		if wd, err := os.Getwd(); err == nil {
+			baseDir = wd
+		}
+	}
+	if !filepath.IsAbs(baseDir) {
+		if abs, err := filepath.Abs(baseDir); err == nil {
+			baseDir = abs
+		}
+	}
+	baseDir = filepath.Clean(baseDir)
+
+	if r.imagePolicy.SandboxLocal {
+		// Reject absolute paths
+		if filepath.IsAbs(path) || strings.HasPrefix(path, "/") || strings.HasPrefix(path, "\\") ||
+			(len(path) >= 2 && unicode.IsLetter(rune(path[0])) && path[1] == ':') {
+			return "", nil, fmt.Errorf("%w: absolute paths are not permitted in sandboxed mode", ErrSandboxViolation)
+		}
+
+		// Reject file:// bypasses that specify absolute paths
+		if isFileURL && (strings.HasPrefix(path, "/") || strings.HasPrefix(path, "\\") || filepath.IsAbs(path)) {
+			return "", nil, fmt.Errorf("%w: file:// absolute access is not permitted in sandboxed mode", ErrSandboxViolation)
+		}
+
+		// Lexical clean check for traversal
+		cleanedRel := filepath.Clean(path)
+		if cleanedRel == ".." || strings.HasPrefix(cleanedRel, ".."+string(filepath.Separator)) || strings.HasPrefix(cleanedRel, "../") {
+			return "", nil, fmt.Errorf("%w: path traversal outside sandbox is not permitted", ErrSandboxViolation)
+		}
+
+		targetPath := filepath.Join(baseDir, cleanedRel)
+		rel, err := filepath.Rel(baseDir, targetPath)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return "", nil, fmt.Errorf("%w: path escapes base directory", ErrSandboxViolation)
+		}
+
+		// Symlink canonicalization check
+		canonicalBase := baseDir
+		if evalBase, err := filepath.EvalSymlinks(baseDir); err == nil {
+			canonicalBase = filepath.Clean(evalBase)
+		}
+
+		// Check if target or any existing ancestor escapes via symlink
+		if _, err := os.Lstat(targetPath); err == nil {
+			if canonicalTarget, err := filepath.EvalSymlinks(targetPath); err == nil {
+				relTarget, err := filepath.Rel(canonicalBase, canonicalTarget)
+				if err != nil || relTarget == ".." || strings.HasPrefix(relTarget, ".."+string(filepath.Separator)) {
+					return "", nil, fmt.Errorf("%w: symlink target %q escapes base directory", ErrSandboxViolation, canonicalTarget)
+				}
+			}
+		} else {
+			// Find deepest existing ancestor to check for symlink escapes in parent dirs
+			curr := targetPath
+			for {
+				parent := filepath.Dir(curr)
+				if parent == curr || parent == "." {
+					break
+				}
+				if _, statErr := os.Lstat(parent); statErr == nil {
+					if evalParent, evalErr := filepath.EvalSymlinks(parent); evalErr == nil {
+						relParent, relErr := filepath.Rel(canonicalBase, evalParent)
+						if relErr != nil || relParent == ".." || strings.HasPrefix(relParent, ".."+string(filepath.Separator)) {
+							return "", nil, fmt.Errorf("%w: symlink parent directory escapes base directory", ErrSandboxViolation)
+						}
+					}
+					break
+				}
+				curr = parent
+			}
+		}
+
+		loader := func() (image.Image, error) {
+			f, err := os.Open(targetPath)
+			if err != nil {
+				return nil, err
+			}
+			defer func() { _ = f.Close() }()
+
+			cfg, _, err := image.DecodeConfig(f)
+			if err != nil {
+				return nil, err
+			}
+			if err := r.checkDimensions(cfg.Width, cfg.Height); err != nil {
+				return nil, err
+			}
+			if _, err := f.Seek(0, io.SeekStart); err != nil {
+				return nil, err
+			}
+			img, _, err := image.Decode(f)
+			if err != nil {
+				return nil, err
+			}
+			return img, nil
+		}
+		return targetPath, loader, nil
+	}
+
+	// Non-sandboxed (trusted) mode:
+	cleaned := path
+	if !filepath.IsAbs(cleaned) {
+		if baseDir != "" {
+			cleaned = filepath.Join(baseDir, cleaned)
+		}
+	}
+	cleaned = filepath.Clean(cleaned)
 	if !filepath.IsAbs(cleaned) {
 		if abs, err := filepath.Abs(cleaned); err == nil {
 			cleaned = abs
 		}
 	}
+
 	loader := func() (image.Image, error) {
 		f, err := os.Open(cleaned)
 		if err != nil {
 			return nil, err
 		}
 		defer func() { _ = f.Close() }()
+
+		cfg, _, err := image.DecodeConfig(f)
+		if err != nil {
+			return nil, err
+		}
+		if err := r.checkDimensions(cfg.Width, cfg.Height); err != nil {
+			return nil, err
+		}
+		if _, err := f.Seek(0, io.SeekStart); err != nil {
+			return nil, err
+		}
 		img, _, err := image.Decode(f)
 		if err != nil {
 			return nil, err
@@ -670,13 +884,24 @@ func (r *renderer) resolveLocalImage(dest string) (string, func() (image.Image, 
 }
 
 func (r *renderer) resolveRemoteImage(dest string) (string, func() (image.Image, error), error) {
+	if !r.imagePolicy.AllowRemote {
+		return "", nil, fmt.Errorf("%w: remote image loading is disabled", ErrPolicyDenied)
+	}
 	url := strings.TrimSpace(dest)
 	loader := func() (image.Image, error) {
 		client := r.httpClient
 		if client == nil {
 			client = http.DefaultClient
 		}
-		resp, err := client.Get(url)
+		ctx := r.imagePolicy.Context
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return nil, err
+		}
+		resp, err := client.Do(req)
 		if err != nil {
 			return nil, err
 		}
@@ -684,7 +909,39 @@ func (r *renderer) resolveRemoteImage(dest string) (string, func() (image.Image,
 		if resp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("md2png: fetching image %s: %s", url, resp.Status)
 		}
-		img, _, err := image.Decode(resp.Body)
+
+		if r.imagePolicy.MaxRemoteBytes > 0 && resp.ContentLength > r.imagePolicy.MaxRemoteBytes {
+			return nil, fmt.Errorf("%w: remote image content length %d exceeds limit of %d bytes", ErrResourceLimit, resp.ContentLength, r.imagePolicy.MaxRemoteBytes)
+		}
+
+		var bodyReader io.Reader = resp.Body
+		if r.imagePolicy.MaxRemoteBytes > 0 {
+			bodyReader = io.LimitReader(resp.Body, r.imagePolicy.MaxRemoteBytes+1)
+		}
+
+		data, err := io.ReadAll(bodyReader)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil, ctx.Err()
+			}
+			return nil, err
+		}
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		if r.imagePolicy.MaxRemoteBytes > 0 && int64(len(data)) > r.imagePolicy.MaxRemoteBytes {
+			return nil, fmt.Errorf("%w: remote image size exceeds limit of %d bytes", ErrResourceLimit, r.imagePolicy.MaxRemoteBytes)
+		}
+
+		cfg, _, err := image.DecodeConfig(bytes.NewReader(data))
+		if err != nil {
+			return nil, err
+		}
+		if err := r.checkDimensions(cfg.Width, cfg.Height); err != nil {
+			return nil, err
+		}
+		img, _, err := image.Decode(bytes.NewReader(data))
 		if err != nil {
 			return nil, err
 		}
@@ -1043,8 +1300,14 @@ func (r *renderer) renderListItem(li *ast.ListItem, md []byte, level int, marker
 	}
 
 	inlineBlock := func(node ast.Node) {
+		if r.renderErr != nil {
+			return
+		}
 		var tokens []textToken
 		r.collectInlineTokens(node, md, r.c.fonts.Regular, r.baseSize, r.c.th.FG, &tokens)
+		if r.renderErr != nil {
+			return
+		}
 		if len(tokens) == 0 {
 			text := strings.TrimRight(getNodeText(node, md), "\n")
 			if text == "" {
@@ -1064,6 +1327,9 @@ func (r *renderer) renderListItem(li *ast.ListItem, md []byte, level int, marker
 	}
 
 	for child := li.FirstChild(); child != nil; child = child.NextSibling() {
+		if r.renderErr != nil {
+			return
+		}
 		switch c := child.(type) {
 		case *ast.Paragraph:
 			inlineBlock(c)
@@ -1094,6 +1360,9 @@ func (r *renderer) renderListItem(li *ast.ListItem, md []byte, level int, marker
 			quoteStart := r.c.cursorY
 			var tokens []textToken
 			r.collectInlineTokens(c, md, r.c.fonts.Regular, r.baseSize, r.c.th.FG, &tokens)
+			if r.renderErr != nil {
+				return
+			}
 			if len(tokens) > 0 {
 				r.c.addVSpace(2)
 				_ = r.c.drawTokens(tokens, contentLeft+10, r.c.w-r.c.margin)
@@ -1114,8 +1383,14 @@ func (r *renderer) renderListItem(li *ast.ListItem, md []byte, level int, marker
 }
 
 func (r *renderer) collectTableRow(row *extensionAST.TableRow, md []byte, isHeader bool) [][]textToken {
+	if r.renderErr != nil {
+		return nil
+	}
 	var cells [][]textToken
 	for cell := row.FirstChild(); cell != nil; cell = cell.NextSibling() {
+		if r.renderErr != nil {
+			return nil
+		}
 		if tc, ok := cell.(*extensionAST.TableCell); ok {
 			var tokens []textToken
 			font := r.c.fonts.Regular
@@ -1123,6 +1398,9 @@ func (r *renderer) collectTableRow(row *extensionAST.TableRow, md []byte, isHead
 				font = r.c.fonts.Bold
 			}
 			r.collectInlineTokens(tc, md, font, r.baseSize, r.c.th.FG, &tokens)
+			if r.renderErr != nil {
+				return nil
+			}
 			cells = append(cells, tokens)
 		}
 	}
@@ -1130,25 +1408,21 @@ func (r *renderer) collectTableRow(row *extensionAST.TableRow, md []byte, isHead
 }
 
 func (r *renderer) renderTable(tbl *extensionAST.Table, md []byte) {
+	if r.renderErr != nil {
+		return
+	}
 	var rows [][][]textToken
 	for node := tbl.FirstChild(); node != nil; node = node.NextSibling() {
+		if r.renderErr != nil {
+			return
+		}
 		switch n := node.(type) {
 		case *extensionAST.TableHeader:
-			// The children of TableHeader are TableCell, not TableRow!
-			// We need to collect the cells directly.
-			// Actually, wait, goldmark v1.7.4 might be different from whatever was assumed.
-			// Let's create a pseudo-row just to pass to a logic, or adjust.
-			// The original code was:
-			/*
-				for child := n.FirstChild(); child != nil; child = child.NextSibling() {
-					if tr, ok := child.(*extensionAST.TableRow); ok {
-						rows = append(rows, r.collectTableRow(tr, md, true))
-					}
-				}
-			*/
-			// Since we know TableHeader directly contains TableCells, let's collect them!
 			var cells [][]textToken
 			for cell := n.FirstChild(); cell != nil; cell = cell.NextSibling() {
+				if r.renderErr != nil {
+					return
+				}
 				if tc, ok := cell.(*extensionAST.TableCell); ok {
 					var tokens []textToken
 					font := r.c.fonts.Regular
@@ -1156,6 +1430,9 @@ func (r *renderer) renderTable(tbl *extensionAST.Table, md []byte) {
 						font = r.c.fonts.Bold
 					}
 					r.collectInlineTokens(tc, md, font, r.baseSize, r.c.th.FG, &tokens)
+					if r.renderErr != nil {
+						return
+					}
 					cells = append(cells, tokens)
 				}
 			}
@@ -1306,6 +1583,9 @@ func (r *renderer) render(md []byte) error {
 			}
 			var tokens []textToken
 			r.collectInlineTokens(n, md, r.c.fonts.Regular, size, r.c.th.FG, &tokens)
+			if r.renderErr != nil {
+				return ast.WalkStop, r.renderErr
+			}
 			r.c.addVSpace(int(r.baseSize * 0.75))
 			_ = r.c.drawTokens(tokens, r.c.margin, r.c.w-r.c.margin)
 			r.c.addVSpace(int(r.baseSize * 0.5))
@@ -1313,6 +1593,9 @@ func (r *renderer) render(md []byte) error {
 		case *ast.Paragraph:
 			var tokens []textToken
 			r.collectInlineTokens(n, md, r.c.fonts.Regular, r.baseSize, r.c.th.FG, &tokens)
+			if r.renderErr != nil {
+				return ast.WalkStop, r.renderErr
+			}
 			if len(tokens) > 0 {
 				_ = r.c.drawTokens(tokens, r.c.margin, r.c.w-r.c.margin)
 				r.c.addVSpace(int(r.baseSize * 0.9))
@@ -1320,9 +1603,15 @@ func (r *renderer) render(md []byte) error {
 			return ast.WalkSkipChildren, nil
 		case *ast.List:
 			r.renderList(nd, md, 0)
+			if r.renderErr != nil {
+				return ast.WalkStop, r.renderErr
+			}
 			return ast.WalkSkipChildren, nil
 		case *extensionAST.Table:
 			r.renderTable(nd, md)
+			if r.renderErr != nil {
+				return ast.WalkStop, r.renderErr
+			}
 			return ast.WalkSkipChildren, nil
 		case *ast.CodeBlock, *ast.FencedCodeBlock:
 			text := strings.TrimRight(getNodeText(n, md), "\n")
@@ -1333,6 +1622,9 @@ func (r *renderer) render(md []byte) error {
 			startY := r.c.cursorY
 			var tokens []textToken
 			r.collectInlineTokens(n, md, r.c.fonts.Regular, r.baseSize*1.0, r.c.th.FG, &tokens)
+			if r.renderErr != nil {
+				return ast.WalkStop, r.renderErr
+			}
 			if len(tokens) > 0 {
 				r.c.addVSpace(2)
 				_ = r.c.drawTokens(tokens, r.c.margin+10, r.c.w-r.c.margin)

--- a/md2png.go
+++ b/md2png.go
@@ -608,11 +608,14 @@ func (r *renderer) ensureImageResolvers() {
 				}
 				if origCheckRedirect != nil {
 					if err := origCheckRedirect(req, via); err != nil {
+						if errors.Is(err, http.ErrUseLastResponse) {
+							return http.ErrUseLastResponse
+						}
 						return fmt.Errorf("%w: redirect rejected: %w", ErrPolicyDenied, err)
 					}
 				}
 				if len(via) >= 10 {
-					return errors.New("stopped after 10 redirects")
+					return fmt.Errorf("%w: stopped after 10 redirects", ErrPolicyDenied)
 				}
 				return nil
 			}
@@ -625,7 +628,7 @@ func (r *renderer) ensureImageResolvers() {
 						return fmt.Errorf("%w: disallowed redirect scheme %q", ErrPolicyDenied, req.URL.Scheme)
 					}
 					if len(via) >= 10 {
-						return errors.New("stopped after 10 redirects")
+						return fmt.Errorf("%w: stopped after 10 redirects", ErrPolicyDenied)
 					}
 					return nil
 				},

--- a/md2png.go
+++ b/md2png.go
@@ -513,6 +513,7 @@ type renderer struct {
 	imageResolvers map[string]imageResolver
 	httpClient     *http.Client
 	imagePolicy    ImagePolicy
+	renderErr      error
 }
 
 type imageResolver func(dest string) (cacheKey string, loader func() (image.Image, error), err error)
@@ -693,6 +694,9 @@ func (r *renderer) resolveRemoteImage(dest string) (string, func() (image.Image,
 }
 
 func (r *renderer) collectInlineTokens(node ast.Node, md []byte, font *FontAndFace, size float64, color color.Color, out *[]textToken) {
+	if r.renderErr != nil {
+		return
+	}
 	if font == nil {
 		font = r.c.fonts.Regular
 	}

--- a/md2png.go
+++ b/md2png.go
@@ -755,7 +755,10 @@ func (r *renderer) collectInlineTokens(node ast.Node, md []byte, font *FontAndFa
 					errors.Is(err, ErrPolicyDenied) ||
 					errors.Is(err, ErrResourceLimit) ||
 					errors.Is(err, ErrSandboxViolation) {
-					panic(err) // let Render recover this and return correctly
+					if r.renderErr == nil {
+						r.renderErr = err
+					}
+					return
 				}
 				fallback := alt
 				fallbackColor := r.c.th.FG
@@ -1279,6 +1282,9 @@ func (r *renderer) render(md []byte) error {
 	)
 	doc := mdParser.Parser().Parse(text.NewReader(md))
 	if err := ast.Walk(doc, func(n ast.Node, entering bool) (ast.WalkStatus, error) {
+		if r.renderErr != nil {
+			return ast.WalkStop, r.renderErr
+		}
 		if !entering {
 			return ast.WalkContinue, nil
 		}
@@ -1352,6 +1358,9 @@ func (r *renderer) render(md []byte) error {
 		}
 	}); err != nil {
 		return err
+	}
+	if r.renderErr != nil {
+		return r.renderErr
 	}
 	r.drawFootnotes()
 	return nil

--- a/md2png.go
+++ b/md2png.go
@@ -1466,19 +1466,12 @@ type RenderOptions struct {
 // or result in no useful drawable area (width <= 2*margin) will return sentinel errors.
 func Render(data []byte, opts RenderOptions) (resImg *image.RGBA, resErr error) {
 	defer func() {
-		if rv := recover(); rv != nil {
-			if err, ok := rv.(error); ok {
-				if strings.HasPrefix(err.Error(), "md2png: maximum output height limit exceeded") ||
-					errors.Is(err, context.DeadlineExceeded) ||
-					errors.Is(err, context.Canceled) ||
-					errors.Is(err, ErrPolicyDenied) ||
-					errors.Is(err, ErrResourceLimit) ||
-					errors.Is(err, ErrSandboxViolation) {
-					resErr = err
-					return
-				}
+		if r := recover(); r != nil {
+			if err, ok := r.(error); ok && strings.HasPrefix(err.Error(), "md2png: maximum output height limit exceeded") {
+				resErr = err
+			} else {
+				panic(r)
 			}
-			panic(rv)
 		}
 	}()
 

--- a/md2png_test.go
+++ b/md2png_test.go
@@ -528,3 +528,35 @@ func TestRenderBeyond8192px(t *testing.T) {
 		t.Fatalf("expected meaningful rendered pixels (link) near the bottom of a >8192px image")
 	}
 }
+
+func TestRendererFallbackBehaviour(t *testing.T) {
+	markdown := "Paragraph with a ![missing image](file:///non-existent-file.png)."
+
+	// This uses the DefaultCLIImagePolicy which allows local images
+	opts := RenderOptions{ImagePolicy: &ImagePolicy{AllowLocal: true, SandboxLocal: false}}
+
+	// The image file does not exist. Since it's just a regular file-not-found error,
+	// it should NOT cause a fatal error. It should use the fallback mechanism.
+	img, err := Render([]byte(markdown), opts)
+	if err != nil {
+		t.Fatalf("expected success with fallback, got error: %v", err)
+	}
+	if img == nil {
+		t.Fatalf("expected an image returned")
+	}
+}
+
+func TestRendererUnrelatedPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected unrelated panic to propagate")
+		}
+	}()
+
+	// Intentionally trigger a nil pointer dereference by bypassing RenderOptions defaults
+	// (Actually, Render populates defaults, so we'll just panic directly via a bad option)
+	// Or we can just test the fallback test and rely on Go runtime panic for real bugs.
+	// Since we removed our custom panic handling, standard panics naturally propagate.
+	var p *int
+	_ = *p // provoke an immediate panic
+}

--- a/md2png_test.go
+++ b/md2png_test.go
@@ -545,18 +545,3 @@ func TestRendererFallbackBehaviour(t *testing.T) {
 		t.Fatalf("expected an image returned")
 	}
 }
-
-func TestRendererUnrelatedPanic(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Fatalf("expected unrelated panic to propagate")
-		}
-	}()
-
-	// Intentionally trigger a nil pointer dereference by bypassing RenderOptions defaults
-	// (Actually, Render populates defaults, so we'll just panic directly via a bad option)
-	// Or we can just test the fallback test and rely on Go runtime panic for real bugs.
-	// Since we removed our custom panic handling, standard panics naturally propagate.
-	var p *int
-	_ = *p // provoke an immediate panic
-}

--- a/md2png_test.go
+++ b/md2png_test.go
@@ -7,6 +7,7 @@ import (
 	"image/color"
 	"image/draw"
 	"image/png"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,6 +15,12 @@ import (
 	"strings"
 	"testing"
 )
+
+type mockTransport func(*http.Request) (*http.Response, error)
+
+func (m mockTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return m(req)
+}
 
 func TestWrapLinesPreservesIndentation(t *testing.T) {
 	fonts, err := LoadFonts(FontConfig{SizeBase: 14})
@@ -103,11 +110,24 @@ func TestRendererFootnoteCollection(t *testing.T) {
 		t.Fatalf("load fonts: %v", err)
 	}
 	c := newCanvas(640, 48, lightTheme, fonts, 16, 32768)
+	mockClient := &http.Client{
+		Transport: mockTransport(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Status:     "404 Not Found",
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	policy := DefaultCLIImagePolicy()
+	policy.HTTPClient = mockClient
 	r := &renderer{
 		c:              c,
 		baseSize:       16,
 		linkFootnotes:  true,
 		imageFootnotes: true,
+		imagePolicy:    policy,
 	}
 	r.ensureImageResolvers()
 	markdown := []byte("First [link](https://example.com) and second [same](https://example.com) ![img](https://example.com/image.png)")
@@ -128,11 +148,24 @@ func TestRendererFootnoteToggles(t *testing.T) {
 		t.Fatalf("load fonts: %v", err)
 	}
 	c := newCanvas(640, 48, lightTheme, fonts, 16, 32768)
+	mockClient := &http.Client{
+		Transport: mockTransport(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusNotFound,
+				Status:     "404 Not Found",
+				Body:       io.NopCloser(strings.NewReader("")),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+	policy := DefaultCLIImagePolicy()
+	policy.HTTPClient = mockClient
 	r := &renderer{
 		c:              c,
 		baseSize:       16,
 		linkFootnotes:  false,
 		imageFootnotes: true,
+		imagePolicy:    policy,
 	}
 	r.ensureImageResolvers()
 	markdown := []byte("[link](https://example.com) ![img](https://example.com/image.png)")

--- a/policy_test.go
+++ b/policy_test.go
@@ -1,0 +1,699 @@
+package md2png
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func createTestPNG(t *testing.T, width, height int) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, width, height))
+	draw.Draw(img, img.Bounds(), &image.Uniform{color.RGBA{R: 200, G: 50, B: 50, A: 255}}, image.Point{}, draw.Src)
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("failed to encode test png: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func writeTestImage(t *testing.T, path string, width, height int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatalf("failed to create dir: %v", err)
+	}
+	data := createTestPNG(t, width, height)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("failed to write test image: %v", err)
+	}
+}
+
+func TestPolicy_LocalImagesDisabled(t *testing.T) {
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "local.png")
+	writeTestImage(t, imgPath, 20, 20)
+
+	opts := RenderOptions{
+		BaseDir: dir,
+		ImagePolicy: &ImagePolicy{
+			AllowLocal: false,
+		},
+	}
+	_, err := Render([]byte("![img](local.png)"), opts)
+	if err == nil {
+		t.Fatalf("expected error when local images are disabled, got nil")
+	}
+	if !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("expected errors.Is(err, ErrPolicyDenied), got: %v", err)
+	}
+}
+
+func TestPolicy_RemoteImagesDisabled(t *testing.T) {
+	opts := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote: false,
+		},
+	}
+	_, err := Render([]byte("![img](http://127.0.0.1:9999/image.png)"), opts)
+	if err == nil {
+		t.Fatalf("expected error when remote images are disabled, got nil")
+	}
+	if !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("expected errors.Is(err, ErrPolicyDenied), got: %v", err)
+	}
+}
+
+func TestPolicy_SandboxTraversalEscapeRejected(t *testing.T) {
+	baseDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideFile := filepath.Join(outsideDir, "secret.png")
+	writeTestImage(t, outsideFile, 20, 20)
+
+	opts := RenderOptions{
+		BaseDir: baseDir,
+		ImagePolicy: &ImagePolicy{
+			AllowLocal:   true,
+			SandboxLocal: true,
+		},
+	}
+
+	testCases := []string{
+		"![img](../secret.png)",
+		"![img](../../secret.png)",
+		"![img](sub/../../secret.png)",
+		"![img](sub/../..//../secret.png)",
+	}
+
+	for _, tc := range testCases {
+		_, err := Render([]byte(tc), opts)
+		if err == nil {
+			t.Fatalf("expected sandbox violation for %q, got nil", tc)
+		}
+		if !errors.Is(err, ErrSandboxViolation) {
+			t.Fatalf("expected errors.Is(err, ErrSandboxViolation) for %q, got: %v", tc, err)
+		}
+	}
+}
+
+func TestPolicy_SandboxAbsoluteLocalPathRejected(t *testing.T) {
+	baseDir := t.TempDir()
+	opts := RenderOptions{
+		BaseDir: baseDir,
+		ImagePolicy: &ImagePolicy{
+			AllowLocal:   true,
+			SandboxLocal: true,
+		},
+	}
+
+	testCases := []string{
+		"![img](/etc/passwd)",
+		"![img](/tmp/secret.png)",
+	}
+
+	for _, tc := range testCases {
+		_, err := Render([]byte(tc), opts)
+		if err == nil {
+			t.Fatalf("expected sandbox violation for %q, got nil", tc)
+		}
+		if !errors.Is(err, ErrSandboxViolation) {
+			t.Fatalf("expected errors.Is(err, ErrSandboxViolation) for %q, got: %v", tc, err)
+		}
+	}
+}
+
+func TestPolicy_SandboxFileURIBypassRejected(t *testing.T) {
+	baseDir := t.TempDir()
+	opts := RenderOptions{
+		BaseDir: baseDir,
+		ImagePolicy: &ImagePolicy{
+			AllowLocal:   true,
+			SandboxLocal: true,
+		},
+	}
+
+	testCases := []string{
+		"![img](file:///etc/passwd)",
+		"![img](file:///tmp/secret.png)",
+		"![img](file://localhost/etc/passwd)",
+		"![img](file://localhost/tmp/secret.png)",
+	}
+
+	for _, tc := range testCases {
+		_, err := Render([]byte(tc), opts)
+		if err == nil {
+			t.Fatalf("expected sandbox violation for %q, got nil", tc)
+		}
+		if !errors.Is(err, ErrSandboxViolation) {
+			t.Fatalf("expected errors.Is(err, ErrSandboxViolation) for %q, got: %v", tc, err)
+		}
+	}
+}
+
+func TestPolicy_SandboxSymlinkEscapeRejected(t *testing.T) {
+	baseDir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsideImg := filepath.Join(outsideDir, "secret.png")
+	writeTestImage(t, outsideImg, 20, 20)
+
+	symlinkPath := filepath.Join(baseDir, "symlink.png")
+	if err := os.Symlink(outsideImg, symlinkPath); err != nil {
+		t.Skipf("skipping symlink test (symlinks not supported): %v", err)
+	}
+
+	opts := RenderOptions{
+		BaseDir: baseDir,
+		ImagePolicy: &ImagePolicy{
+			AllowLocal:     true,
+			SandboxLocal:   true,
+			MaxImageWidth:  1000,
+			MaxImageHeight: 1000,
+			MaxImagePixels: 1000000,
+		},
+	}
+
+	_, err := Render([]byte("![img](symlink.png)"), opts)
+	if err == nil {
+		t.Fatalf("expected sandbox violation for symlink escape, got nil")
+	}
+	if !errors.Is(err, ErrSandboxViolation) {
+		t.Fatalf("expected errors.Is(err, ErrSandboxViolation), got: %v", err)
+	}
+}
+
+func TestPolicy_ValidFileInsideBaseDir(t *testing.T) {
+	baseDir := t.TempDir()
+	imgPath := filepath.Join(baseDir, "images", "valid.png")
+	writeTestImage(t, imgPath, 20, 20)
+
+	opts := RenderOptions{
+		BaseDir: baseDir,
+		ImagePolicy: &ImagePolicy{
+			AllowLocal:     true,
+			SandboxLocal:   true,
+			MaxImageWidth:  1000,
+			MaxImageHeight: 1000,
+			MaxImagePixels: 1000000,
+		},
+	}
+
+	img, err := Render([]byte("![valid](images/valid.png)"), opts)
+	if err != nil {
+		t.Fatalf("expected success for valid sandboxed file, got error: %v", err)
+	}
+	if img == nil {
+		t.Fatalf("expected non-nil image returned")
+	}
+}
+
+func TestPolicy_RemoteRequestUsingSuppliedHTTPClient(t *testing.T) {
+	pngData := createTestPNG(t, 20, 20)
+	var requestCount int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngData)
+	}))
+	defer server.Close()
+
+	customClient := server.Client()
+
+	opts := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote:    true,
+			HTTPClient:     customClient,
+			MaxImageWidth:  1000,
+			MaxImageHeight: 1000,
+			MaxImagePixels: 1000000,
+			MaxRemoteBytes: 1024 * 1024,
+		},
+	}
+
+	img, err := Render([]byte(fmt.Sprintf("![remote](%s/test.png)", server.URL)), opts)
+	if err != nil {
+		t.Fatalf("expected success with custom HTTP client, got error: %v", err)
+	}
+	if img == nil {
+		t.Fatalf("expected non-nil image returned")
+	}
+	if atomic.LoadInt32(&requestCount) == 0 {
+		t.Fatalf("expected custom HTTP client to be invoked")
+	}
+}
+
+func TestPolicy_RedirectToDisallowedDestinationRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "file:///etc/passwd", http.StatusFound)
+	}))
+	defer server.Close()
+
+	opts := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote:    true,
+			HTTPClient:     server.Client(),
+			MaxRemoteBytes: 1024 * 1024,
+		},
+	}
+
+	_, err := Render([]byte(fmt.Sprintf("![redirect](%s/img.png)", server.URL)), opts)
+	if err == nil {
+		t.Fatalf("expected error for disallowed redirect scheme, got nil")
+	}
+	if !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("expected errors.Is(err, ErrPolicyDenied), got: %v", err)
+	}
+}
+
+func TestPolicy_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(createTestPNG(t, 20, 20))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel before rendering
+
+	opts := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote: true,
+			HTTPClient:  server.Client(),
+			Context:     ctx,
+		},
+	}
+
+	_, err := Render([]byte(fmt.Sprintf("![img](%s/test.png)", server.URL)), opts)
+	if err == nil {
+		t.Fatalf("expected cancellation error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected errors.Is(err, context.Canceled), got: %v", err)
+	}
+}
+
+func TestPolicy_ContextDeadlineTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(createTestPNG(t, 20, 20))
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	opts := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote: true,
+			HTTPClient:  server.Client(),
+			Context:     ctx,
+		},
+	}
+
+	_, err := Render([]byte(fmt.Sprintf("![img](%s/test.png)", server.URL)), opts)
+	if err == nil {
+		t.Fatalf("expected timeout error, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected errors.Is(err, context.DeadlineExceeded), got: %v", err)
+	}
+}
+
+func TestPolicy_ResponseBodyExceedingMaxRemoteBytes(t *testing.T) {
+	pngData := createTestPNG(t, 100, 100) // ~few KB
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngData)
+	}))
+	defer server.Close()
+
+	opts := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote:    true,
+			HTTPClient:     server.Client(),
+			MaxRemoteBytes: 50, // limit is 50 bytes, PNG is much larger
+		},
+	}
+
+	_, err := Render([]byte(fmt.Sprintf("![img](%s/test.png)", server.URL)), opts)
+	if err == nil {
+		t.Fatalf("expected resource limit error for excessive bytes, got nil")
+	}
+	if !errors.Is(err, ErrResourceLimit) {
+		t.Fatalf("expected errors.Is(err, ErrResourceLimit), got: %v", err)
+	}
+}
+
+func TestPolicy_ExcessiveWidth(t *testing.T) {
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "wide.png")
+	writeTestImage(t, imgPath, 200, 20)
+
+	opts := RenderOptions{
+		BaseDir: dir,
+		ImagePolicy: &ImagePolicy{
+			AllowLocal:     true,
+			MaxImageWidth:  100,
+			MaxImageHeight: 1000,
+			MaxImagePixels: 1000000,
+		},
+	}
+
+	_, err := Render([]byte("![wide](wide.png)"), opts)
+	if err == nil {
+		t.Fatalf("expected resource limit error for excessive width, got nil")
+	}
+	if !errors.Is(err, ErrResourceLimit) {
+		t.Fatalf("expected errors.Is(err, ErrResourceLimit), got: %v", err)
+	}
+}
+
+func TestPolicy_ExcessiveHeight(t *testing.T) {
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "tall.png")
+	writeTestImage(t, imgPath, 20, 200)
+
+	opts := RenderOptions{
+		BaseDir: dir,
+		ImagePolicy: &ImagePolicy{
+			AllowLocal:     true,
+			MaxImageWidth:  1000,
+			MaxImageHeight: 100,
+			MaxImagePixels: 1000000,
+		},
+	}
+
+	_, err := Render([]byte("![tall](tall.png)"), opts)
+	if err == nil {
+		t.Fatalf("expected resource limit error for excessive height, got nil")
+	}
+	if !errors.Is(err, ErrResourceLimit) {
+		t.Fatalf("expected errors.Is(err, ErrResourceLimit), got: %v", err)
+	}
+}
+
+func TestPolicy_ExcessiveTotalPixels(t *testing.T) {
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "square.png")
+	writeTestImage(t, imgPath, 100, 100) // 10,000 pixels
+
+	opts := RenderOptions{
+		BaseDir: dir,
+		ImagePolicy: &ImagePolicy{
+			AllowLocal:     true,
+			MaxImageWidth:  500,
+			MaxImageHeight: 500,
+			MaxImagePixels: 5000, // limit is 5000 pixels
+		},
+	}
+
+	_, err := Render([]byte("![square](square.png)"), opts)
+	if err == nil {
+		t.Fatalf("expected resource limit error for excessive pixels, got nil")
+	}
+	if !errors.Is(err, ErrResourceLimit) {
+		t.Fatalf("expected errors.Is(err, ErrResourceLimit), got: %v", err)
+	}
+}
+
+func TestPolicy_NormalLocalImageBelowLimits(t *testing.T) {
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "normal.png")
+	writeTestImage(t, imgPath, 50, 50)
+
+	opts := RenderOptions{
+		BaseDir: dir,
+		ImagePolicy: &ImagePolicy{
+			AllowLocal:     true,
+			SandboxLocal:   true,
+			MaxImageWidth:  100,
+			MaxImageHeight: 100,
+			MaxImagePixels: 10000,
+		},
+	}
+
+	img, err := Render([]byte("![normal](normal.png)"), opts)
+	if err != nil {
+		t.Fatalf("expected success for image below limits, got error: %v", err)
+	}
+	if img == nil {
+		t.Fatalf("expected non-nil image returned")
+	}
+}
+
+func TestPolicy_NormalRemoteImageBelowLimits(t *testing.T) {
+	pngData := createTestPNG(t, 50, 50)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngData)
+	}))
+	defer server.Close()
+
+	opts := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote:    true,
+			HTTPClient:     server.Client(),
+			MaxRemoteBytes: 100 * 1024,
+			MaxImageWidth:  100,
+			MaxImageHeight: 100,
+			MaxImagePixels: 10000,
+		},
+	}
+
+	img, err := Render([]byte(fmt.Sprintf("![normal](%s/normal.png)", server.URL)), opts)
+	if err != nil {
+		t.Fatalf("expected success for remote image below limits, got error: %v", err)
+	}
+	if img == nil {
+		t.Fatalf("expected non-nil image returned")
+	}
+}
+
+func TestPolicy_BoundedCache(t *testing.T) {
+	dir := t.TempDir()
+	writeTestImage(t, filepath.Join(dir, "img1.png"), 10, 10)
+	writeTestImage(t, filepath.Join(dir, "img2.png"), 10, 10)
+	writeTestImage(t, filepath.Join(dir, "img3.png"), 10, 10)
+
+	policy := ImagePolicy{
+		AllowLocal:     true,
+		MaxCacheItems:  2,
+		MaxImageWidth:  100,
+		MaxImageHeight: 100,
+		MaxImagePixels: 10000,
+	}
+
+	fonts, err := LoadFonts(FontConfig{SizeBase: 16})
+	if err != nil {
+		t.Fatalf("load fonts: %v", err)
+	}
+	c := newCanvas(640, 48, lightTheme, fonts, 16, 32768)
+	r := &renderer{
+		c:           c,
+		baseSize:    16,
+		baseDir:     dir,
+		imagePolicy: policy,
+	}
+	r.ensureImageResolvers()
+
+	// Load img1
+	if _, err := r.loadImage("img1.png"); err != nil {
+		t.Fatalf("loadImage 1 failed: %v", err)
+	}
+	// Load img2
+	if _, err := r.loadImage("img2.png"); err != nil {
+		t.Fatalf("loadImage 2 failed: %v", err)
+	}
+	if len(r.imageCache) != 2 {
+		t.Fatalf("expected 2 items in cache, got %d", len(r.imageCache))
+	}
+
+	// Load img3: should evict img1 (FIFO)
+	if _, err := r.loadImage("img3.png"); err != nil {
+		t.Fatalf("loadImage 3 failed: %v", err)
+	}
+	if len(r.imageCache) != 2 {
+		t.Fatalf("expected cache size to stay at 2, got %d", len(r.imageCache))
+	}
+	key1 := filepath.Join(dir, "img1.png")
+	if _, ok := r.imageCache[key1]; ok {
+		t.Fatalf("expected img1 to be evicted from cache")
+	}
+	key2 := filepath.Join(dir, "img2.png")
+	key3 := filepath.Join(dir, "img3.png")
+	if _, ok := r.imageCache[key2]; !ok {
+		t.Fatalf("expected img2 to be retained in cache")
+	}
+	if _, ok := r.imageCache[key3]; !ok {
+		t.Fatalf("expected img3 to be retained in cache")
+	}
+}
+
+func TestPolicy_TrustedMissingImageFallback(t *testing.T) {
+	markdown := "Paragraph with ![missing](non-existent-image-12345.png)."
+	img, err := Render([]byte(markdown), RenderOptions{})
+	if err != nil {
+		t.Fatalf("expected non-fatal fallback in default trusted mode, got error: %v", err)
+	}
+	if img == nil {
+		t.Fatalf("expected image rendered with fallback text")
+	}
+}
+
+func TestPolicy_StrictImagePolicy(t *testing.T) {
+	strict := StrictImagePolicy()
+	if strict.AllowLocal {
+		t.Errorf("StrictImagePolicy should have AllowLocal = false")
+	}
+	if strict.AllowRemote {
+		t.Errorf("StrictImagePolicy should have AllowRemote = false")
+	}
+	if !strict.SandboxLocal {
+		t.Errorf("StrictImagePolicy should have SandboxLocal = true")
+	}
+
+	opts := RenderOptions{ImagePolicy: &strict}
+	_, err := Render([]byte("![local](foo.png)"), opts)
+	if !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("expected ErrPolicyDenied for local image under strict policy, got: %v", err)
+	}
+
+	_, err = Render([]byte("![remote](https://example.com/foo.png)"), opts)
+	if !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("expected ErrPolicyDenied for remote image under strict policy, got: %v", err)
+	}
+}
+
+func TestPolicy_CallerSuppliedCheckRedirectPreserved(t *testing.T) {
+	errCustomRedirect := errors.New("custom redirect denied")
+	var redirectChecked int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			http.Redirect(w, r, "/target", http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(createTestPNG(t, 20, 20))
+	}))
+	defer server.Close()
+
+	customClient := server.Client()
+	customClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		atomic.AddInt32(&redirectChecked, 1)
+		return errCustomRedirect
+	}
+
+	opts := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote: true,
+			HTTPClient:  customClient,
+		},
+	}
+
+	_, err := Render([]byte(fmt.Sprintf("![img](%s/start)", server.URL)), opts)
+	if err == nil {
+		t.Fatalf("expected error from caller-supplied CheckRedirect, got nil")
+	}
+	if !errors.Is(err, errCustomRedirect) {
+		t.Fatalf("expected error to wrap errCustomRedirect, got: %v", err)
+	}
+	if atomic.LoadInt32(&redirectChecked) == 0 {
+		t.Fatalf("expected caller CheckRedirect to be invoked")
+	}
+}
+
+func TestPolicy_CallerHTTPClientNotMutated(t *testing.T) {
+	origClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
+	origCheckRedirect := origClient.CheckRedirect
+
+	opts := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote: true,
+			HTTPClient:  origClient,
+		},
+	}
+
+	_, _ = Render([]byte("![test](http://127.0.0.1:99999/dummy.png)"), opts)
+
+	if origClient.CheckRedirect != nil && origCheckRedirect == nil {
+		t.Fatalf("caller-owned http.Client was mutated: CheckRedirect was overwritten")
+	}
+}
+
+func TestPolicy_ChunkedResponseExceedingMaxRemoteBytes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Use chunked encoding (no Content-Length header)
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatalf("expected ResponseWriter to be Flusher")
+		}
+		w.Header().Set("Content-Type", "image/png")
+		w.WriteHeader(http.StatusOK)
+		// Write 50 bytes and flush
+		chunk1 := bytes.Repeat([]byte("A"), 50)
+		_, _ = w.Write(chunk1)
+		flusher.Flush()
+		// Write another 50 bytes and flush
+		chunk2 := bytes.Repeat([]byte("B"), 50)
+		_, _ = w.Write(chunk2)
+		flusher.Flush()
+	}))
+	defer server.Close()
+
+	opts := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote:    true,
+			HTTPClient:     server.Client(),
+			MaxRemoteBytes: 60, // Total sent is 100 bytes, limit is 60
+		},
+	}
+
+	_, err := Render([]byte(fmt.Sprintf("![chunked](%s/chunked.png)", server.URL)), opts)
+	if err == nil {
+		t.Fatalf("expected resource limit error for chunked stream exceeding MaxRemoteBytes, got nil")
+	}
+	if !errors.Is(err, ErrResourceLimit) {
+		t.Fatalf("expected errors.Is(err, ErrResourceLimit), got: %v", err)
+	}
+}
+
+func TestPolicy_RemoteImageExcessiveDimensions(t *testing.T) {
+	pngData := createTestPNG(t, 200, 200) // 200x200
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(pngData)
+	}))
+	defer server.Close()
+
+	opts := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote:    true,
+			HTTPClient:     server.Client(),
+			MaxRemoteBytes: 1024 * 1024,
+			MaxImageWidth:  50, // limit is 50px
+		},
+	}
+
+	_, err := Render([]byte(fmt.Sprintf("![wide](%s/wide.png)", server.URL)), opts)
+	if err == nil {
+		t.Fatalf("expected resource limit error for remote image exceeding width, got nil")
+	}
+	if !errors.Is(err, ErrResourceLimit) {
+		t.Fatalf("expected errors.Is(err, ErrResourceLimit), got: %v", err)
+	}
+}

--- a/policy_test.go
+++ b/policy_test.go
@@ -607,11 +607,91 @@ func TestPolicy_CallerSuppliedCheckRedirectPreserved(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error from caller-supplied CheckRedirect, got nil")
 	}
+	if !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("expected errors.Is(err, ErrPolicyDenied), got: %v", err)
+	}
 	if !errors.Is(err, errCustomRedirect) {
 		t.Fatalf("expected error to wrap errCustomRedirect, got: %v", err)
 	}
 	if atomic.LoadInt32(&redirectChecked) == 0 {
 		t.Fatalf("expected caller CheckRedirect to be invoked")
+	}
+}
+
+func TestPolicy_CallerSuppliedCheckRedirectErrUseLastResponse(t *testing.T) {
+	var redirectChecked int32
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/start" {
+			http.Redirect(w, r, "/target", http.StatusFound)
+			return
+		}
+		w.Header().Set("Content-Type", "image/png")
+		_, _ = w.Write(createTestPNG(t, 20, 20))
+	}))
+	defer server.Close()
+
+	customClient := server.Client()
+	customClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		atomic.AddInt32(&redirectChecked, 1)
+		return http.ErrUseLastResponse
+	}
+
+	opts := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote: true,
+			HTTPClient:  customClient,
+		},
+	}
+
+	img, err := Render([]byte(fmt.Sprintf("![alt text](%s/start)", server.URL)), opts)
+	if errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("expected http.ErrUseLastResponse to not be transformed into ErrPolicyDenied, got: %v", err)
+	}
+	if err != nil {
+		t.Fatalf("expected non-fatal fallback when redirect stops via ErrUseLastResponse, got error: %v", err)
+	}
+	if img == nil {
+		t.Fatalf("expected non-nil image with fallback alt text")
+	}
+	if atomic.LoadInt32(&redirectChecked) == 0 {
+		t.Fatalf("expected caller CheckRedirect to be invoked")
+	}
+}
+
+func TestPolicy_RedirectCountExceededFails(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "/loop", http.StatusFound)
+	}))
+	defer server.Close()
+
+	// Default client
+	optsDefault := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote: true,
+		},
+	}
+	_, err := Render([]byte(fmt.Sprintf("![img](%s/loop)", server.URL)), optsDefault)
+	if err == nil {
+		t.Fatalf("expected error for redirect loop with default client, got nil")
+	}
+	if !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("expected errors.Is(err, ErrPolicyDenied) on redirect count limit with default client, got: %v", err)
+	}
+
+	// Caller-supplied client
+	optsCustom := RenderOptions{
+		ImagePolicy: &ImagePolicy{
+			AllowRemote: true,
+			HTTPClient:  server.Client(),
+		},
+	}
+	_, err = Render([]byte(fmt.Sprintf("![img](%s/loop)", server.URL)), optsCustom)
+	if err == nil {
+		t.Fatalf("expected error for redirect loop with custom client, got nil")
+	}
+	if !errors.Is(err, ErrPolicyDenied) {
+		t.Fatalf("expected errors.Is(err, ErrPolicyDenied) on redirect count limit with custom client, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
This draft PR introduces an explicit public image-loading policy to mitigate security risks associated with loading local and remote images during Markdown rendering.

Fixes #61
Fixes #62

### Changes

1. **`ImagePolicy` Struct**: Introduced `md2png.ImagePolicy` to define rules for fetching and decoding images. This includes controls for `AllowLocal`, `SandboxLocal`, `AllowRemote`, `MaxRemoteBytes`, `HTTPClient`, `Context`, `MaxCacheItems`, and strict dimensional/pixel limits (`MaxImageWidth`, `MaxImageHeight`, `MaxImagePixels`).
2. **Conservative Defaults**: Added `StrictImagePolicy()` for rendering untrusted Markdown safely, and `DefaultCLIImagePolicy()` to retain backwards-compatible, relaxed behaviour for trusted CLI environments.
3. **Local Sandboxing**: When `SandboxLocal` is true, the renderer actively checks `filepath.Clean` and verifies paths against the absolute `BaseDir` to explicitly reject `..` directory traversal and rogue absolute paths.
4. **Remote Restrictions**: Uses `io.LimitReader` for HTTP downloads based on `MaxRemoteBytes`, enforces HTTP redirects to only allow `http/https` schemes (preventing SSRF via `file://`), and respects Context timeouts (`context.DeadlineExceeded`).
5. **Pre-Decode Limits**: For both local and remote images, the renderer uses `image.DecodeConfig` to assert dimensional limits *before* calling `image.Decode()`, preventing memory exhaustion or OOM errors from large logical image payloads.
6. **Error Handing**: Explicit policy denials, resource limit violations, sandbox escapes, and context timeouts are bubbled up safely via typed sentinel errors (`ErrPolicyDenied`, `ErrSandboxViolation`, `ErrResourceLimit`) utilizing `errors.Is`. Trusted legacy rendering retains its best-effort fallback behaviour for normal file-not-found/network errors.

### Validation

- Tested with `go test ./...` and `go vet ./...` (All tests passing)
- Linting using `golangci-lint` and `gofmt` verified
- Verified no-real Internet dependency testing architecture
- Tested rendering with `go run ./cmd/md2png --in README.md --out output.png`
- Comprehensive unit tests mock an HTTP server safely simulating oversized limits, timeouts, and schema traversal.

---
*PR created automatically by Jules for task [8535684826695705808](https://jules.google.com/task/8535684826695705808) started by @arran4*